### PR TITLE
Internal: Scroll view in article page from private to public

### DIFF
--- a/Sources/SATSCore/Components/ArticlePageView/ArticlePageView.swift
+++ b/Sources/SATSCore/Components/ArticlePageView/ArticlePageView.swift
@@ -103,7 +103,7 @@ public class ArticlePageView: UIView {
         return stackView
     }()
 
-    private lazy var scrollView: UIScrollView = {
+    public lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView(withAutoLayout: true)
         scrollView.delegate = self
         scrollView.contentInset.top = headerHeight


### PR DESCRIPTION
# Why?

ScrollView needs to be accessible for fixing the tab bar issue in ArticleViewController

# What?

Scroll view in Article page is now a public instance

# Version Change

Minor change