### PR TITLE
Feature: Add weigth to Font in ButtonStyle

### DIFF
--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
@@ -8,8 +8,8 @@ public extension View {
     ///   - size: size of the button (`.basic` by default)
     ///   - isLoading: a booelan to indicate if we need to show a spinner on the button instead of the button text
     /// - Returns: applies the `buttonStyle` modifier to the current view
-    func satsButton(_ style: SATSButton.Style, size: SATSButton.Size = .basic, isLoading: Bool = false) -> some View {
-        buttonStyle(SATSButtonSwiftUIStyle(style, size: size, isLoading: isLoading))
+    func satsButton(_ style: SATSButton.Style, size: SATSButton.Size = .basic, isLoading: Bool = false, weight: SATSFont.Weight = .medium) -> some View {
+        buttonStyle(SATSButtonSwiftUIStyle(style, size: size, isLoading: isLoading, weight: weight))
     }
 }
 
@@ -20,12 +20,14 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
     let style: SATSButton.Style
     let size: SATSButton.Size
     let isLoading: Bool
+    let weight: SATSFont.Weight
     @Environment(\.isEnabled) private var isEnabled
 
-    init(_ style: SATSButton.Style, size: SATSButton.Size, isLoading: Bool) {
+    init(_ style: SATSButton.Style, size: SATSButton.Size, isLoading: Bool, weight: SATSFont.Weight = .medium) {
         self.style = style
         self.size = size
         self.isLoading = isLoading
+        self.weight = weight
     }
 
     func makeBody(configuration: Configuration) -> some View {
@@ -53,7 +55,7 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
     func buttonContent(for configuration: Configuration) -> some View {
         configuration
             .label
-            .satsFont(.button, weight: .medium)
+            .satsFont(.button, weight: weight)
             .textCase(.uppercase)
     }
 


### PR DESCRIPTION
# Why?

Change weight for buttons

# What?

Add a optional parameter to have the possibility to change weight on a SATSButton

# Version Change

This is a **minor** change
- The button has a new feature, you can change the the font weight if needed.

# UI Changes
Look at the font weight on the `I ACCEPT` button
| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-09-20 at 07 52 23](https://user-images.githubusercontent.com/31440186/191177791-e7f1c79d-b645-42cf-ab90-8c02aca208d8.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-09-20 at 07 50 31](https://user-images.githubusercontent.com/31440186/191177615-38719127-1f6b-4ca9-8848-b9157c2b33bc.png) |

