### PR TITLE
Improvement: use dividers in RadioGroup component

### DIFF
--- a/Sources/SATSCore/Components/RadioGroup/RadioGroup.swift
+++ b/Sources/SATSCore/Components/RadioGroup/RadioGroup.swift
@@ -18,14 +18,26 @@ public struct RadioGroup<Option: Identifiable, Label: View>: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             ForEach(options) { option in
-                HStack(spacing: .spacingM) {
-                    RadioButton(isSelected: option.id == selected.id)
-                    label(option)
+                radioButtonRow(for: option)
+
+                if shouldAddDivider(for: option) {
+                    Divider()
                 }
-                .padding(EdgeInsets(vertical: .spacingM, horizontal: 0))
-                .onTapGesture { selected = option }
             }
         }
+    }
+
+    private func radioButtonRow(for option: Option) -> some View {
+        HStack(spacing: .spacingM) {
+            RadioButton(isSelected: option.id == selected.id)
+            label(option)
+        }
+        .padding(EdgeInsets(vertical: .spacingM, horizontal: 0))
+        .onTapGesture { selected = option }
+    }
+
+    private func shouldAddDivider(for option: Option) -> Bool {
+        option.id != options.last?.id
     }
 }
 


### PR DESCRIPTION
# Why?

According to design a radio group should use a divider between rows of radio buttons.

# What?

Add a divider between rows except for the last. This behaviour mimics how `List` works when the separator is visible. 
I opted to NOT use `List` to get this behaviour for free since this would cause issues when using RadioGroup inside a List or a ScrollView.

# Version Change

This is a patch.

# UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-09-20 at 18 56 30](https://user-images.githubusercontent.com/57347029/191320123-23f69240-475b-4514-a39e-3b25bfb7298f.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-09-20 at 18 56 06](https://user-images.githubusercontent.com/57347029/191320167-072b7bff-e516-4421-9f71-76538eeccdef.png) |