### PR TITLE
Fix: Typo in RadioGroupView Demo

### DIFF
--- a/DemoApp/DemoApp/Views/Components/RadioGroupView/RadioGroupDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/RadioGroupView/RadioGroupDemoView.swift
@@ -41,7 +41,7 @@ extension RadioGroupDemoView {
                 return "Cardio"
 
             case .studioTraining:
-                return "Strenght"
+                return "Strength"
             }
         }
     }


### PR DESCRIPTION
# Why?

The word was written incorrectly.

# What?

Change “Strenght” typo to “Strength”.

# Version Change

Probably just a patch.