### PR TITLE
Feature: Action theme colors

### DIFF
--- a/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
+++ b/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
@@ -43,6 +43,14 @@ struct ColorDemoView: View {
             ]
         ),
         ColorSection(
+            name: "Action",
+            colors: [
+                ColorDemo(name: "action", color: .action),
+                ColorDemo(name: "actionHighlight", color: .actionHighlight),
+                ColorDemo(name: "actionDisabled", color: .actionDisabled),
+            ]
+        ),
+        ColorSection(
             name: "Clean",
             colors: [
                 ColorDemo(name: "clean", color: .clean),

--- a/Sources/SATSCore/Assets/Colors.xcassets/Action/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Action/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/Colors.xcassets/Action/action.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Action/action.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC2",
+          "green" : "0x6A",
+          "red" : "0x02"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDE",
+          "green" : "0x9B",
+          "red" : "0x54"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/Colors.xcassets/Action/actionDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Action/actionDisabled.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAD",
+          "green" : "0xA6",
+          "red" : "0x9F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x29",
+          "green" : "0x27",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/Colors.xcassets/Action/actionHighlight.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/Colors.xcassets/Action/actionHighlight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCD",
+          "green" : "0x80",
+          "red" : "0x25"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF2",
+          "green" : "0xB5",
+          "red" : "0x75"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/DNA/Colors/ColorName.swift
+++ b/Sources/SATSCore/DNA/Colors/ColorName.swift
@@ -99,6 +99,9 @@ enum ColorName: String, CaseIterable {
     case primaryDisabled
 
     case selection
+    case action
+    case actionHighlight
+    case actionDisabled
 
     case backgroundTopStart
     case backgroundTopEnd

--- a/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
@@ -35,6 +35,12 @@ public extension Color {
     static var ctaDisabled: Color { color(.ctaDisabled) }
     static var nonText: Color { color(.nonText) }
 
+    // MARK: Action
+
+    static var action: Color { color(.action) }
+    static var actionHighlight: Color { color(.actionHighlight) }
+    static var actionDisabled: Color { color(.actionDisabled) }
+
     // MARK: Waitlist
 
     static var waitlist: Color { color(.waitlist) }

--- a/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
@@ -33,6 +33,12 @@ public extension UIColor {
     static var ctaDisabled: UIColor { color(.ctaDisabled) }
     static var nonText: UIColor { color(.nonText) }
 
+    // MARK: Action
+
+    static var action: UIColor { color(.action) }
+    static var actionHighlight: UIColor { color(.actionHighlight) }
+    static var actionDisabled: UIColor { color(.actionDisabled) }
+
     // MARK: Waitlist
 
     static var waitlist: UIColor { color(.waitlist) }

--- a/Tests/SATSCoreTests/ColorsTests.swift
+++ b/Tests/SATSCoreTests/ColorsTests.swift
@@ -43,6 +43,10 @@ class ColorsTests: XCTestCase {
             .ctaDisabled,
             .nonText,
 
+            .action,
+            .actionHighlight,
+            .actionDisabled,
+
             .waitlist,
             .waitlistHighlight,
             .waitlistDisabled,


### PR DESCRIPTION
## Why

A visual problem we have with colors in the app is that we don't use a propper `accentColor`.

Then, elements in for example: navigation bar or other plain text buttons are not clearly indicated as clickable content

<img src="https://user-images.githubusercontent.com/167989/192250002-8db22795-475f-47fd-a2d3-1c3113edeb9b.png" width=400 />

A proper way to do this would be to have a proper accent color like the Apple Store App

<img src="https://user-images.githubusercontent.com/167989/192250368-38472773-84f1-47da-9a8c-e6e5df34642f.png" width=350 />

## What

Our theme's primary color is not intended/does not work as to show this clickable text, then it's not suited as a primary color. Noes does our selection color.

This PR adds a new color named **action** color (with the highlighted/disabled variants)

<img src="https://user-images.githubusercontent.com/167989/192249781-aa6e1a79-298f-4d82-84d4-2695425fb380.png" width=400 />

This color shows the user where it's appropriate to tap for actions to happen when it comes to plain text