### PR TITLE
Feature: plain text button style

### DIFF
--- a/DemoApp/DemoApp/Views/BasicComponents/SATSButtonSwiftUIDemoView.swift
+++ b/DemoApp/DemoApp/Views/BasicComponents/SATSButtonSwiftUIDemoView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SATSCore
 
 struct SATSButtonSwftUIDemoView: View {
     @State var size: SATSButton.Size = .basic
@@ -28,42 +29,54 @@ struct SATSButtonSwftUIDemoView: View {
                 }
                 .padding(.horizontal)
 
-                VStack {
-                    Button("Primary", action: {})
-                        .satsButton(.primary, size: size, isLoading: isLoading)
-                        .padding()
+                ScrollView(.vertical) {
+                    VStack {
+                        Button("Primary", action: {})
+                            .satsButton(.primary, size: size, isLoading: isLoading)
+                            .padding()
 
-                    Button("Secondary", action: {})
-                        .satsButton(.secondary, size: size, isLoading: isLoading)
-                        .padding()
+                        Button("Secondary", action: {})
+                            .satsButton(.secondary, size: size, isLoading: isLoading)
+                            .padding()
 
-                    VStack(spacing: 20) {
-                        HStack {
-                            Spacer()
+                        VStack(spacing: 20) {
+                            HStack {
+                                Spacer()
 
-                            Button("Clean", action: {})
-                                .satsButton(.clean, size: size, isLoading: isLoading)
+                                Button("Clean", action: {})
+                                    .satsButton(.clean, size: size, isLoading: isLoading)
 
-                            Spacer()
+                                Spacer()
+                            }
+
+                            HStack {
+                                Spacer()
+
+                                Button("Clean Secondary", action: {})
+                                    .satsButton(.cleanSecondary, size: size, isLoading: isLoading)
+
+                                Spacer()
+                            }
                         }
+                        .padding()
+                        .background(Color.satsPrimary)
 
-                        HStack {
-                            Spacer()
+                        Button("CTA", action: {})
+                            .satsButton(.cta, size: size, isLoading: isLoading)
+                            .padding()
 
-                            Button("Clean Secondary", action: {})
-                                .satsButton(.cleanSecondary, size: size, isLoading: isLoading)
+                        Button("Plain", action: {})
+                            .satsButton(.plain, size: size, isLoading: isLoading)
+                            .padding()
 
-                            Spacer()
+                        Button(action: {}) {
+                            Label("Plain with Image", systemImage: "person.circle")
                         }
+                        .satsButton(.plain, size: size, isLoading: isLoading)
+                        .padding()
                     }
-                    .padding()
-                    .background(Color.satsPrimary)
-
-                    Button("CTA", action: {})
-                        .satsButton(.cta, size: size, isLoading: isLoading)
-                        .padding()
+                    .disabled(!isEnabled)
                 }
-                .disabled(!isEnabled)
 
                 Spacer()
             }
@@ -94,7 +107,8 @@ struct SATSButtonSwftUIDemoView: View {
 
 struct SATSButtonSwftUIDemoView_Previews: PreviewProvider {
     static var previews: some View {
-        Group {
+        SATSFont.registerCustomFonts()
+        return Group {
             NavigationView {
                 SATSButtonSwftUIDemoView()
             }

--- a/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
+++ b/DemoApp/DemoApp/Views/DNA/ColorDemoView.swift
@@ -170,6 +170,10 @@ struct ColorDemoView: View {
 
                 ColorDemo(name: "blueSelection", color: Color(ColorTheme.blue.selection)),
 
+                ColorDemo(name: "blueAction", color: Color(ColorTheme.blue.action)),
+                ColorDemo(name: "blueActionHighlighted", color: Color(ColorTheme.blue.actionHighlighted)),
+                ColorDemo(name: "blueActionDisabled", color: Color(ColorTheme.blue.actionDisabled)),
+
                 ColorDemo(name: "blueGradientStart", color: Color(ColorTheme.blue.backgroundTopStart)),
                 ColorDemo(name: "blueGradientEnd", color: Color(ColorTheme.blue.backgroundTopEnd)),
 
@@ -185,6 +189,10 @@ struct ColorDemoView: View {
 
                 ColorDemo(name: "silverSelection", color: Color(ColorTheme.silver.selection)),
 
+                ColorDemo(name: "silverAction", color: Color(ColorTheme.silver.action)),
+                ColorDemo(name: "silverActionHighlighted", color: Color(ColorTheme.silver.actionHighlighted)),
+                ColorDemo(name: "silverActionDisabled", color: Color(ColorTheme.silver.actionDisabled)),
+
                 ColorDemo(name: "silverGradientStart", color: Color(ColorTheme.silver.backgroundTopStart)),
                 ColorDemo(name: "silverGradientEnd", color: Color(ColorTheme.silver.backgroundTopEnd)),
 
@@ -199,6 +207,10 @@ struct ColorDemoView: View {
                 ColorDemo(name: "goldPrimaryDisabled", color: Color(ColorTheme.gold.primaryDisabled)),
 
                 ColorDemo(name: "goldSelection", color: Color(ColorTheme.gold.selection)),
+
+                ColorDemo(name: "goldAction", color: Color(ColorTheme.gold.action)),
+                ColorDemo(name: "goldActionHighlighted", color: Color(ColorTheme.gold.actionHighlighted)),
+                ColorDemo(name: "goldActionDisabled", color: Color(ColorTheme.gold.actionDisabled)),
 
                 ColorDemo(name: "goldGradientStart", color: Color(ColorTheme.gold.backgroundTopStart)),
                 ColorDemo(name: "goldGradientEnd", color: Color(ColorTheme.gold.backgroundTopEnd)),
@@ -220,6 +232,11 @@ struct ColorDemoView: View {
                 ),
 
                 ColorDemo(name: "platinumSelection", color: Color(ColorTheme.platinum.selection)),
+
+                ColorDemo(name: "platinumAction", color: Color(ColorTheme.platinum.action)),
+                ColorDemo(name: "platinumActionHighlighted", color: Color(ColorTheme.platinum.actionHighlighted)),
+                ColorDemo(name: "platinumActionDisabled", color: Color(ColorTheme.platinum.actionDisabled)),
+
                 ColorDemo(name: "platinumGradientStart", color: Color(ColorTheme.platinum.backgroundTopStart)),
                 ColorDemo(name: "platinumGradientEnd", color: Color(ColorTheme.platinum.backgroundTopEnd)),
 

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Action/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Action/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Action/blueAction.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Action/blueAction.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC2",
+          "green" : "0x6A",
+          "red" : "0x02"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDD",
+          "green" : "0xA4",
+          "red" : "0x61"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Action/blueActionDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Action/blueActionDisabled.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.678",
+          "green" : "0.651",
+          "red" : "0.624"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Action/blueActionHighlighted.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Action/blueActionHighlighted.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x75",
+          "green" : "0x3F",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.851",
+          "blue" : "0xDD",
+          "green" : "0xA4",
+          "red" : "0x61"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Action/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Action/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Action/goldAction.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Action/goldAction.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.280",
+          "green" : "0.497",
+          "red" : "0.604"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.322",
+          "green" : "0.659",
+          "red" : "0.831"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Action/goldActionDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Action/goldActionDisabled.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.678",
+          "green" : "0.651",
+          "red" : "0.624"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Action/goldActionHighlighted.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Gold Theme/Action/goldActionHighlighted.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.204",
+          "green" : "0.220",
+          "red" : "0.224"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.388",
+          "green" : "0.694",
+          "red" : "0.847"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Action/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Action/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Action/platinumAction.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Action/platinumAction.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.761",
+          "green" : "0.416",
+          "red" : "0.008"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.867",
+          "green" : "0.643",
+          "red" : "0.380"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Action/platinumActionDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Action/platinumActionDisabled.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.678",
+          "green" : "0.651",
+          "red" : "0.624"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Action/platinumActionHighlighted.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Platinum Theme/Action/platinumActionHighlighted.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.459",
+          "green" : "0.247",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.851",
+          "blue" : "0.867",
+          "green" : "0.643",
+          "red" : "0.380"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Action/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Action/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Action/silverAction.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Action/silverAction.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.761",
+          "green" : "0.416",
+          "red" : "0.008"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.867",
+          "green" : "0.643",
+          "red" : "0.380"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Action/silverActionDisabled.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Action/silverActionDisabled.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.678",
+          "green" : "0.651",
+          "red" : "0.624"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Action/silverActionHighlighted.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Silver Theme/Action/silverActionHighlighted.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.459",
+          "green" : "0.247",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.851",
+          "blue" : "0.867",
+          "green" : "0.643",
+          "red" : "0.380"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Style.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Style.swift
@@ -6,11 +6,12 @@ public extension SATSButton {
         public let name: String
 
         public let titleColor: UIColor
+        public let titleColorHighlighted: UIColor
         public let titleColorDisabled: UIColor
 
-        public let backgroundColor: UIColor
-        public let backgroundColorHighlighted: UIColor
-        public let backgroundColorDisabled: UIColor
+        public let backgroundColor: UIColor?
+        public let backgroundColorHighlighted: UIColor?
+        public let backgroundColorDisabled: UIColor?
 
         public let borderColor: UIColor?
         public let borderColorDisabled: UIColor?
@@ -18,15 +19,18 @@ public extension SATSButton {
         public init(
             name: String,
             titleColor: UIColor,
+            titleColorHighlighted: UIColor? = nil,
             titleColorDisabled: UIColor,
-            backgroundColor: UIColor,
-            backgroundColorHighlighted: UIColor,
-            backgroundColorDisabled: UIColor,
+            backgroundColor: UIColor? = nil,
+            backgroundColorHighlighted: UIColor? = nil,
+            backgroundColorDisabled: UIColor? = nil,
             borderColor: UIColor? = nil,
             borderColorDisabled: UIColor? = nil
         ) {
             self.name = name
+
             self.titleColor = titleColor
+            self.titleColorHighlighted = titleColorHighlighted ?? titleColor
             self.titleColorDisabled = titleColorDisabled
 
             self.backgroundColor = backgroundColor
@@ -37,7 +41,7 @@ public extension SATSButton {
             self.borderColorDisabled = borderColorDisabled
         }
 
-        func backgroundColor(forState state: UIControl.State) -> UIColor {
+        func backgroundColor(forState state: UIControl.State) -> UIColor? {
             switch state {
             case .highlighted:
                 return backgroundColorHighlighted

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Style.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Style.swift
@@ -110,4 +110,12 @@ public extension SATSButton.Style {
         backgroundColorHighlighted: .ctaHighlight,
         backgroundColorDisabled: .ctaDisabled
     )
+
+    static let plain = SATSButton.Style(
+        name: "Plain",
+        titleColor: .action,
+        titleColorHighlighted: .actionHighlighted,
+        titleColorDisabled: .actionDisabled,
+        backgroundColor: nil
+    )
 }

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
@@ -42,7 +42,7 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
             label.frame(maxWidth: .infinity, alignment: .center)
         })
         .background(backgroundColor(for: configuration))
-        .foregroundColor(textColor)
+        .foregroundColor(textColor(configuration: configuration))
         .clipShape(Capsule())
         .overlay(borderOverlay)
     }
@@ -67,23 +67,24 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
 
     // MARK: Private methods
 
-    private var textColor: Color {
-        Color(isEnabled ? style.titleColor : style.titleColorDisabled)
+    private func textColor(configuration: Configuration) -> Color {
+        if isEnabled {
+            return Color(configuration.isPressed ? style.titleColorHighlighted : style.titleColor)
+        } else {
+            return Color(style.titleColorDisabled)
+        }
     }
 
     private var borderColor: Color? {
         (isEnabled ? style.borderColor : style.borderColorDisabled).map { Color($0) }
     }
 
-    private func backgroundColor(for configuration: Configuration) -> Color {
+    private func backgroundColor(for configuration: Configuration) -> Color? {
         if isEnabled {
-            return Color(
-                configuration.isPressed ?
-                    style.backgroundColorHighlighted :
-                    style.backgroundColor
-            )
+            let uiColor = configuration.isPressed ? style.backgroundColorHighlighted : style.backgroundColor
+            return uiColor.map { Color($0) }
         } else {
-            return Color(style.backgroundColorDisabled)
+            return style.backgroundColorDisabled.map { Color($0) }
         }
     }
 

--- a/Sources/SATSCore/DNA/Colors/ColorName.swift
+++ b/Sources/SATSCore/DNA/Colors/ColorName.swift
@@ -99,6 +99,9 @@ enum ColorName: String, CaseIterable {
     case primaryDisabled
 
     case selection
+    case action
+    case actionHighlighted
+    case actionDisabled
 
     case backgroundTopStart
     case backgroundTopEnd

--- a/Sources/SATSCore/DNA/Colors/ColorTheme.swift
+++ b/Sources/SATSCore/DNA/Colors/ColorTheme.swift
@@ -9,6 +9,11 @@ public struct ColorTheme: Hashable {
     public let primaryDisabled: UIColor
 
     public let selection: UIColor
+    /// Used as the main color for actionable elements
+    /// a.k.a tintColor / accentColor in UIKit/SwiftUI
+    public let action: UIColor
+    public let actionHighlighted: UIColor
+    public let actionDisabled: UIColor
 
     public let backgroundTopStart: UIColor
     public let backgroundTopEnd: UIColor
@@ -22,6 +27,9 @@ public struct ColorTheme: Hashable {
         case .primaryHighlight: return primaryHighlight
         case .primaryDisabled: return primaryDisabled
         case .selection: return selection
+        case .action: return action
+        case .actionHighlighted: return actionHighlighted
+        case .actionDisabled: return actionDisabled
         case .backgroundTopStart: return backgroundTopStart
         case .backgroundTopEnd: return backgroundTopEnd
         case .navigation: return navigation
@@ -93,6 +101,9 @@ public extension ColorTheme {
             primaryHighlight: Self.color("PrimaryHighlight", for: themeName),
             primaryDisabled: Self.color("PrimaryDisabled", for: themeName),
             selection: Self.color("Selection", for: themeName),
+            action: Self.color("Action", for: themeName),
+            actionHighlighted: Self.color("ActionHighlighted", for: themeName),
+            actionDisabled: Self.color("ActionDisabled", for: themeName),
             backgroundTopStart: Self.color("GradientStart", for: themeName),
             backgroundTopEnd: Self.color("GradientEnd", for: themeName),
             navigation: Self.color("Navigation", for: themeName)

--- a/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/SwiftUI-Color.swift
@@ -123,6 +123,10 @@ public extension Color {
 
     static var selection: Color { themedColor(.selection) }
 
+    static var action: Color { themedColor(.action) }
+    static var actionHighlighted: Color { themedColor(.actionHighlighted) }
+    static var actionDisalbed: Color { themedColor(.actionDisabled) }
+
     static var backgroundTopStart: Color { themedColor(.backgroundTopStart) }
     static var backgroundTopEnd: Color { themedColor(.backgroundTopEnd) }
 

--- a/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
@@ -119,6 +119,10 @@ public extension UIColor {
 
     static var selection: UIColor { themedColor(.selection) }
 
+    static var action: UIColor { themedColor(.action) }
+    static var actionHighlighted: UIColor { themedColor(.actionHighlighted) }
+    static var actionDisabled: UIColor { themedColor(.actionDisabled) }
+
     static var backgroundTopStart: UIColor { themedColor(.backgroundTopStart) }
     static var backgroundTopEnd: UIColor { themedColor(.backgroundTopEnd) }
 

--- a/Tests/SATSCoreTests/ColorsTests.swift
+++ b/Tests/SATSCoreTests/ColorsTests.swift
@@ -109,6 +109,9 @@ class ColorsTests: XCTestCase {
             .primaryDisabled,
 
             .selection,
+            .action,
+            .actionHighlighted,
+            .actionDisabled,
 
             .backgroundTopStart,
             .backgroundTopEnd,


### PR DESCRIPTION
# Why?

Given #111, we need to define a button style for plain text.

# What?

This requires some changes in the way the styles are defined and used by `SATSButtonSwiftUIStyle`

# Version Change

minor

# UI Changes

<img src="https://user-images.githubusercontent.com/167989/192251761-398c9c6c-6433-47db-a361-5f19f32c6366.png" width=400 />
