### PR TITLE
Feature: expose initializer for `SATSFont.Weight`

### DIFF
--- a/Sources/SATSCore/DNA/Font/SATSFont-Weight.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-Weight.swift
@@ -2,6 +2,11 @@ import SATSType
 public extension SATSFont {
     /// Style variations for a font regarding its weight
     struct Weight: Equatable, Hashable {
+        public init(name: String, font: FontName) {
+            self.name = name
+            self.font = font
+        }
+
         public static func == (lhs: SATSFont.Weight, rhs: SATSFont.Weight) -> Bool {
             lhs.name == rhs.name
         }


### PR DESCRIPTION
# Why?

Need a font weight that is not specified in SATSCore

# What?

By adding an initialiser, we open up the possibility to change the font weight as desired

We can now add our own weight, ex:
```swift
extension SATSFont.Weight {
    static let italic = SATSFont.Weight(name: "SATS italic", font: InterFont.boldItalic)
}
```

usage:
```swift
Text(viewData.welcomeTitle)
    .satsFont(.h2, weight: .italic)
```

# Version Change

Minor