### PR TITLE
Improvement: update button styles

### DIFF
--- a/DemoApp/DemoApp/Views/BasicComponents/SATSButtonDemoView.swift
+++ b/DemoApp/DemoApp/Views/BasicComponents/SATSButtonDemoView.swift
@@ -8,7 +8,6 @@ struct SATSButtonDemoView: View {
     var settingDescription: String {
         let sizeName: String
         switch size {
-        case .compact: sizeName = "Compact"
         case .basic: sizeName = "Basic"
         case .large: sizeName = "Large"
         default:
@@ -72,7 +71,6 @@ struct SATSButtonDemoView: View {
                     Toggle("Loading", isOn: $isLoading)
 
                     Picker("Size", selection: $size) {
-                        Text("compact").tag(SATSButton.Size.compact)
                         Text("basic").tag(SATSButton.Size.basic)
                         Text("large").tag(SATSButton.Size.large)
                     }

--- a/DemoApp/DemoApp/Views/BasicComponents/SATSButtonSwiftUIDemoView.swift
+++ b/DemoApp/DemoApp/Views/BasicComponents/SATSButtonSwiftUIDemoView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SATSCore
 
 struct SATSButtonSwftUIDemoView: View {
     @State var size: SATSButton.Size = .basic
@@ -8,7 +9,6 @@ struct SATSButtonSwftUIDemoView: View {
     var settingDescription: String {
         let sizeName: String
         switch size {
-        case .compact: sizeName = "Compact"
         case .basic: sizeName = "Basic"
         case .large: sizeName = "Large"
         default:
@@ -78,7 +78,6 @@ struct SATSButtonSwftUIDemoView: View {
                     Toggle("Loading", isOn: $isLoading)
 
                     Picker("Size", selection: $size) {
-                        Text("compact").tag(SATSButton.Size.compact)
                         Text("basic").tag(SATSButton.Size.basic)
                         Text("large").tag(SATSButton.Size.large)
                     }

--- a/DemoApp/DemoApp/Views/UIKit Demo/UIKitDemoView.swift
+++ b/DemoApp/DemoApp/Views/UIKit Demo/UIKitDemoView.swift
@@ -27,7 +27,7 @@ class SampleView: UIView {
     }()
 
     private lazy var button: SATSButton = {
-        let button = SATSButton(style: .primary, size: .compact, withAutoLayout: true)
+        let button = SATSButton(style: .primary, size: .basic, withAutoLayout: true)
         button.setTitle("Push me!", for: .normal)
         return button
     }()

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
@@ -48,14 +48,14 @@ extension SATSButton.Size {
 public extension SATSButton.Size {
     /// Tall primary button, can grow horizontally.
     static let large = SATSButton.Size(
-        contentEdgeInsets: UIEdgeInsets(vertical: 18, horizontal: 30),
+        contentEdgeInsets: UIEdgeInsets(vertical: 16, horizontal: 30),
         imageEdgeInsets: .zero,
         contentHuggingPriority: .defaultHigh
     )
 
     /// Small height but allowed to grow horizontally.
     static let basic = SATSButton.Size(
-        contentEdgeInsets: UIEdgeInsets(vertical: 9, horizontal: 30),
+        contentEdgeInsets: UIEdgeInsets(vertical: 8, horizontal: 24),
         imageEdgeInsets: .zero,
         contentHuggingPriority: .defaultHigh
     )

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
@@ -57,13 +57,6 @@ public extension SATSButton.Size {
     static let basic = SATSButton.Size(
         contentEdgeInsets: UIEdgeInsets(vertical: 9, horizontal: 30),
         imageEdgeInsets: .zero,
-        contentHuggingPriority: .defaultLow
-    )
-
-    /// Compact button that hugs its title as much as possible.
-    static let compact = SATSButton.Size(
-        contentEdgeInsets: UIEdgeInsets(vertical: 9, horizontal: 30),
-        imageEdgeInsets: .zero,
         contentHuggingPriority: .defaultHigh
     )
 }

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
@@ -48,9 +48,9 @@ extension SATSButton.Size {
 public extension SATSButton.Size {
     /// Tall primary button, can grow horizontally.
     static let large = SATSButton.Size(
-        contentEdgeInsets: UIEdgeInsets(all: 16),
+        contentEdgeInsets: UIEdgeInsets(vertical: 18, horizontal: 30),
         imageEdgeInsets: .zero,
-        contentHuggingPriority: .defaultLow
+        contentHuggingPriority: .defaultHigh
     )
 
     /// Small height but allowed to grow horizontally.

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
@@ -53,7 +53,7 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
     func buttonContent(for configuration: Configuration) -> some View {
         configuration
             .label
-            .satsFont(.button, weight: .medium)
+            .satsFont(.button, weight: .emphasis)
             .textCase(.uppercase)
     }
 


### PR DESCRIPTION
# Why?

The design system has updated the button sizes, SATSCore needs to reflect that

Changes reviewed with magnus.

# What?

- Remove `.compact` button size
- Update the parameters for the `.basic` size, which is more like the `.compact` size was
- Update the parameters for the `.large` size
- Update to the right weight for the font for buttons `.emphasis`

# Version Change

**breaking** change

# UI Changes

| | Before | After |
|:---| --- | --- |
| Basic Size | <img width="564" alt="basic - 01" src="https://user-images.githubusercontent.com/167989/196154339-71497e50-4d1f-4950-a38d-b08d11e9637e.png"> | <img width="564" alt="basic - 02" src="https://user-images.githubusercontent.com/167989/196154334-4bd9d39b-8f26-4042-9a5f-a3b78f8a613b.png"> |
| Large Size | <img width="564" alt="large - 01" src="https://user-images.githubusercontent.com/167989/196154318-0d326792-3b98-4465-b29b-ccaed0109a3f.png"> | <img width="564" alt="large - 02" src="https://user-images.githubusercontent.com/167989/196154331-edd691a6-45b4-4f3a-9814-734cfe596ff2.png"> |

