### PR TITLE
Improvement: update notice design

### DIFF
--- a/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 struct NoticeDemoView: View {
     @State var notice: Notice?
 
-    @State var includeSubtitle: Bool = false
-    @State var autoDismiss: Bool = true
+    @State var includeSubtitle: Bool = true
+    @State var autoDismiss: Bool = false
     @State var edgeTop: Bool = true
-    @State var withAction: Bool = false
+    @State var withAction: Bool = true
     @State var style: Style = .success
 
     var edge: Notice.Edge { edgeTop ? .top : .bottom }
@@ -131,9 +131,11 @@ struct ErrorNoticeView_Previews: PreviewProvider {
         Group {
             NoticeDemoView()
                 .background(Color.red)
-                .previewDevice("iPhone 12 Pro")
+                .previewDisplayName("Full Demo")
 
-            Group {
+            VStack(spacing: .spacingL) {
+                Spacer()
+
                 NoticeView(notice: .sampleSuccess)
 
                 NoticeView(notice: .sampleWarning)
@@ -141,7 +143,12 @@ struct ErrorNoticeView_Previews: PreviewProvider {
                 NoticeView(notice: .sampleError)
 
                 NoticeView(notice: .sampleErrorWithAction)
+
+                Spacer()
             }
+            .padding()
+            .background(Color.backgroundPrimary)
+            .previewDisplayName("Notice Showcase")
             .previewLayout(.sizeThatFits)
         }
     }

--- a/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
@@ -52,6 +52,7 @@ struct NoticeDemoView: View {
                 Spacer()
 
                 Picker("\(style.rawValue)", selection: $style) {
+                    Text("Info").tag(Style.info)
                     Text("Success").tag(Style.success)
                     Text("Warning").tag(Style.warning)
                     Text("Error").tag(Style.error)
@@ -85,6 +86,13 @@ struct NoticeDemoView: View {
         let subtitle = includeSubtitle ? "Subtitle text" : nil
 
         switch (style, withAction) {
+        case (.info, _):
+            return Notice.info(
+                title: "Sample info notice",
+                explanation: subtitle,
+                autoDismiss: autoDismiss
+            )
+
         case (.success, _):
             return Notice.success(
                 title: "Sample success notice",
@@ -120,6 +128,7 @@ struct NoticeDemoView: View {
     // In general I favor struct values over enums as they are
     // extensible outside the library
     enum Style: String, Hashable {
+        case info = "Info"
         case success = "Success"
         case warning = "Warning"
         case error = "Error"
@@ -135,6 +144,8 @@ struct ErrorNoticeView_Previews: PreviewProvider {
 
             VStack(spacing: .spacingL) {
                 Spacer()
+
+                NoticeView(notice: .sampleInfo)
 
                 NoticeView(notice: .sampleSuccess)
 
@@ -172,5 +183,9 @@ extension Notice {
 
     static let sampleWarning = Notice.warning(
         title: "You should be careful about this!"
+    )
+
+    static let sampleInfo = Notice.info(
+        title: "We have a new notice style"
     )
 }

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -91,7 +91,7 @@ public struct Notice {
     ///   - explanation: (optional) explanation of the warning
     ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
-    /// - Returns: a `Notice` instance that can be used with `NoticeView
+    /// - Returns: a `Notice` instance that can be used with `NoticeView`
     public static func warning(
         title: String,
         explanation: String? = nil,
@@ -114,7 +114,7 @@ public struct Notice {
     ///   - explanation: (optional) explanation of the notice
     ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
-    /// - Returns: a `Notice` instance that can be used with `NoticeView
+    /// - Returns: a `Notice` instance that can be used with `NoticeView`
     public static func success(
         title: String,
         explanation: String? = nil,
@@ -127,6 +127,29 @@ public struct Notice {
             explanation: explanation,
             autoDismiss: autoDismiss,
             tintColor: .signalSuccess,
+            hapticType: includeHaptic ? .success : nil
+        )
+    }
+
+    /// Creates a info notice data struct
+    /// - Parameters:
+    ///   - title: required title of the notice
+    ///   - explanation: (optional) explanation of the notice
+    ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
+    ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
+    /// - Returns: a `Notice` instance that can be used with `NoticeView`
+    public static func info(
+        title: String,
+        explanation: String? = nil,
+        autoDismiss: Bool = true,
+        includeHaptic: Bool = true
+    ) -> Notice {
+        Notice(
+            icon: Image(systemName: "info.circle"),
+            title: title,
+            explanation: explanation,
+            autoDismiss: autoDismiss,
+            tintColor: .graphicalElements1,
             hapticType: includeHaptic ? .success : nil
         )
     }

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -9,8 +9,7 @@ public struct Notice {
     public let title: String
     public let explanation: String?
     public let autoDismiss: Bool
-    public let foregroundColor: Color
-    public let backgroundColor: Color
+    public let tintColor: Color
     public let hapticType: UINotificationFeedbackGenerator.FeedbackType?
     public let actionTitle: String?
     public let action: (() -> Void)?
@@ -20,8 +19,7 @@ public struct Notice {
         title: String,
         explanation: String? = nil,
         autoDismiss: Bool = true,
-        foregroundColor: Color,
-        backgroundColor: Color,
+        tintColor: Color,
         hapticType: UINotificationFeedbackGenerator.FeedbackType? = nil,
         actionTitle: String? = nil,
         action: (() -> Void)? = nil
@@ -30,8 +28,7 @@ public struct Notice {
         self.title = title
         self.explanation = explanation
         self.autoDismiss = autoDismiss
-        self.foregroundColor = foregroundColor
-        self.backgroundColor = backgroundColor
+        self.tintColor = tintColor
         self.hapticType = hapticType
         self.actionTitle = actionTitle
         self.action = action
@@ -55,8 +52,7 @@ public struct Notice {
             title: title,
             explanation: explanation,
             autoDismiss: autoDismiss,
-            foregroundColor: .onSignal,
-            backgroundColor: .signalError,
+            tintColor: .signalError,
             hapticType: includeHaptic ? .error : nil
         )
     }
@@ -82,8 +78,7 @@ public struct Notice {
             title: title,
             explanation: explanation,
             autoDismiss: false,
-            foregroundColor: .onSignal,
-            backgroundColor: .signalError,
+            tintColor: .signalError,
             hapticType: includeHaptic ? .error : nil,
             actionTitle: actionTitle,
             action: action
@@ -108,8 +103,7 @@ public struct Notice {
             title: title,
             explanation: explanation,
             autoDismiss: autoDismiss,
-            foregroundColor: .onSignal,
-            backgroundColor: .signalWarning,
+            tintColor: .signalWarning,
             hapticType: includeHaptic ? .warning : nil
         )
     }
@@ -132,8 +126,7 @@ public struct Notice {
             title: title,
             explanation: explanation,
             autoDismiss: autoDismiss,
-            foregroundColor: .onSignal,
-            backgroundColor: .signalSuccess,
+            tintColor: .signalSuccess,
             hapticType: includeHaptic ? .success : nil
         )
     }

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -48,7 +48,7 @@ public struct Notice {
         includeHaptic: Bool = true
     ) -> Notice {
         Notice(
-            icon: Image(systemName: "xmark.octagon.fill"),
+            icon: Image(systemName: "xmark.octagon"),
             title: title,
             explanation: explanation,
             autoDismiss: autoDismiss,
@@ -74,7 +74,7 @@ public struct Notice {
         action: @escaping () -> Void
     ) -> Notice {
         Notice(
-            icon: Image(systemName: "xmark.octagon.fill"),
+            icon: Image(systemName: "xmark.octagon"),
             title: title,
             explanation: explanation,
             autoDismiss: false,
@@ -99,7 +99,7 @@ public struct Notice {
         includeHaptic: Bool = true
     ) -> Notice {
         Notice(
-            icon: Image(systemName: "exclamationmark.triangle.fill"),
+            icon: Image(systemName: "exclamationmark.triangle"),
             title: title,
             explanation: explanation,
             autoDismiss: autoDismiss,
@@ -122,7 +122,7 @@ public struct Notice {
         includeHaptic: Bool = true
     ) -> Notice {
         Notice(
-            icon: Image(systemName: "checkmark.circle.fill"),
+            icon: Image(systemName: "checkmark.circle"),
             title: title,
             explanation: explanation,
             autoDismiss: autoDismiss,

--- a/Sources/SATSCore/Components/NoticeView/NoticeView.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeView.swift
@@ -16,13 +16,13 @@ public struct NoticeView: View {
             Spacer()
             actionButton
         }
-        .foregroundColor(notice.foregroundColor)
         .padding(16)
-        .background(notice.backgroundColor)
+        .background(Color.backgroundSurfacePrimary)
         .cornerRadius(8)
         .padding(8)
         .onTapGesture(perform: performTap)
         .frame(maxWidth: .readableWidthM)
+        .shadow(radius: .cornerRadiusS)
     }
 
     func performTap() {
@@ -38,6 +38,7 @@ public struct NoticeView: View {
                 Button(action: onAction) {
                     Text(actionTitle.uppercased())
                         .satsFont(.basic, weight: .emphasis)
+                        .foregroundColor(.onSurfacePrimary)
                 }
                 .padding(.horizontal, 8)
             }
@@ -47,18 +48,21 @@ public struct NoticeView: View {
     @ViewBuilder var icon: some View {
         if let icon = notice.icon {
             icon
+                .font(.system(size: .spacingL, weight: .medium))
+                .foregroundColor(notice.tintColor)
         }
     }
 
     var message: some View {
-        VStack(alignment: .leading, spacing: 1) {
+        VStack(alignment: .leading, spacing: .spacingXXXS) {
             Text(notice.title)
                 .satsFont(.basic, weight: .emphasis)
 
             if let explanation = notice.explanation {
                 Text(explanation)
-                    .satsFont(.small)
+                    .satsFont(.basic, weight: .medium)
             }
         }
+        .foregroundColor(.onSurfaceSecondary)
     }
 }


### PR DESCRIPTION
# Why?

In darkmode, some configurations were not that legible.
Then Magnus updated the styling for the notice

> **Warning**: this depends on #118 as I want to release both breaking changes together

# What?

- Remove unnecessary properties from `Notice`
- Update the styling for `NoticeView`
- Add `Notice.info` styling

# Version Change

**breaking change**

# UI Changes

| Before | After |
| --- | --- |
| <img width="872" alt="notice - old" src="https://user-images.githubusercontent.com/167989/200526858-82aa4d5c-1b46-4698-93d1-343c8df8ab54.png"> | <img width="872" alt="notice - new" src="https://user-images.githubusercontent.com/167989/200526842-68140c6c-c6fa-44a0-a723-6f9f9db36b6c.png"> |

