### PR TITLE
Improvement: adjust primary dark color

### DIFF
--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Primary/bluePrimary.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Primary/bluePrimary.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xDE",
-          "green" : "0x9B",
-          "red" : "0x54"
+          "blue" : "0xB0",
+          "green" : "0x76",
+          "red" : "0x26"
         }
       },
       "idiom" : "universal"

--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Primary/bluePrimaryHighlight.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Primary/bluePrimaryHighlight.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xE1",
-          "green" : "0xA5",
-          "red" : "0x65"
+          "blue" : "0xCC",
+          "green" : "0x8A",
+          "red" : "0x30"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
# Why?

The previous primary dark color was not very accessible

# Version Change

patch

# UI Changes

| Before | After |
| --- | --- |
| <img width="384" alt="before" src="https://user-images.githubusercontent.com/167989/201938002-05781165-d074-44bd-85da-bcb95b1aafe7.png"> | <img width="384" alt="after" src="https://user-images.githubusercontent.com/167989/201938011-00dd6f74-4390-4154-9c91-374d7ab6e5a1.png"> |
