### PR TITLE
Fix: update navigation color value for dark mode

### DIFF
--- a/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Navigation/blueNavigation.colorset/Contents.json
+++ b/Sources/SATSCore/Assets/ThemeColors.xcassets/Blue Theme/Navigation/blueNavigation.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xC3",
-          "red" : "0x9E"
+          "blue" : "0xDE",
+          "green" : "0x9B",
+          "red" : "0x54"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
from `#9EC3FF` to `#549BDE`

This should match what we changed for the primary color in dark mode

This is a continuation from what I did in #121 

These colors should match, otherwise we end-up with UI like:

<img width="400" alt="Screenshot 2022-11-16 at 15 44 40" src="https://user-images.githubusercontent.com/167989/202211664-19ae974a-3a4c-4784-9a15-0c0824d03385.png">

Then it looks weird when `#2` is the same but `#1` is different

# Version Change

patch


