### PR TITLE
Internal: add backport for scrollDismissesKeyboard

### DIFF
--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
@@ -6,4 +6,41 @@ public extension View {
 
 public extension Backport where Content: View {
     // here there will backported extensions when needed for iOS 16
+    @ViewBuilder
+    func scrollDismissesKeyboard(_ visibility: ScrollDismissesKeyboard) -> some View {
+        if #available(iOS 16, *) {
+            content
+                .scrollDismissesKeyboard(visibility.mode)
+        } else {
+            content
+        }
+    }
+
+    enum ScrollDismissesKeyboard {
+        // Determine the mode automatically based on the surrounding context
+        case automatic
+        // Dismiss the keyboard as soon as scrolling starts
+        case immediately
+        // Enable people to interactively dismiss the keyboard as part of the scroll operation
+        case interactively
+        // Never dismiss the keyboard automatically as a result of scrolling
+        case never
+
+        @available(iOS 16, *)
+        var mode: ScrollDismissesKeyboardMode {
+            switch self {
+            case .automatic:
+                return .automatic
+
+            case .immediately:
+                return .immediately
+
+            case .interactively:
+                return .interactively
+
+            case .never:
+                return .never
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Why?

iOS 16 introduces a neat modifier which allows us to dismiss the keyboard when the user scrolls. This can be useful for the workout logger and potentially other features.

# What?

Add a backport for `scrolldismissesKeyboard(:visibility)`. this method accepts a parameter which is also only available for iOS 16, which means I needed to create a custom object which mirrors it.

# Version Change

This is a minor change