### PR TITLE
Improvement: move types from the main app

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -549,7 +549,8 @@
 /* Begin PBXShellScriptBuildPhase section */
 		9B83387825D30FFB0083B6D1 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			alwaysOutOfDate = 1;
+			buildActionMask = 12;
 			files = (
 			);
 			inputFileListPaths = (

--- a/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "SATSType",
-        "repositoryURL": "https://github.com/healthfitnessnordic/SATSType-iOS.git",
+        "repositoryURL": "https://github.com/sats-group/SATSType-iOS.git",
         "state": {
           "branch": null,
           "revision": "3ba28b89b06c6e241cc6615219acb94ea9cdba0e",

--- a/Sources/SATSCore/BasicComponents/SATSGradient/View-SATSGradient.swift
+++ b/Sources/SATSCore/BasicComponents/SATSGradient/View-SATSGradient.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct SATSGradient: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    let fallbackColor: Color
+
+    func body(content: Content) -> some View {
+        content.background(backgroundGradient)
+    }
+
+    var backgroundGradient: some View {
+        Group {
+            if colorScheme == .light {
+                LinearGradient(
+                    stops: [
+                        .init(color: .graphicalElements1.opacity(0), location: 0),
+                        .init(color: .graphicalElements1.opacity(1), location: 0.22),
+                        .init(color: .graphicalElements1.opacity(0), location: 0.65),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .opacity(0.2)
+                .background(Color.backgroundSecondary)
+            } else {
+                fallbackColor
+            }
+        }
+        .ignoresSafeArea()
+    }
+}
+
+public extension View {
+    func satsGradientBackground(fallbackColor: Color = .backgroundPrimary) -> some View {
+        modifier(SATSGradient(fallbackColor: fallbackColor))
+    }
+}

--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
@@ -5,9 +5,20 @@ public extension View {
 }
 
 public extension Backport where Content: View {
+    /// This is needed as TextViews in iOS 16 have an extra background
+    @available(iOS, deprecated: 16, message: "This is a backported version that is not neeeded anymore")
+    @ViewBuilder func hideScrollContentBackground() -> some View {
+        if #available(iOS 16.0, *) {
+            content
+                .scrollContentBackground(.hidden)
+        } else {
+            content
+        }
+    }
+
     // here there will backported extensions when needed for iOS 16
-    @ViewBuilder
-    func scrollDismissesKeyboard(_ visibility: ScrollDismissesKeyboard) -> some View {
+    @available(iOS, deprecated: 16, message: "This is a backported version that is not neeeded anymore")
+    @ViewBuilder func scrollDismissesKeyboard(_ visibility: ScrollDismissesKeyboard) -> some View {
         if #available(iOS 16, *) {
             content
                 .scrollDismissesKeyboard(visibility.mode)
@@ -16,6 +27,7 @@ public extension Backport where Content: View {
         }
     }
 
+    @available(iOS, deprecated: 16, message: "This is a backported version that is not neeeded anymore")
     enum ScrollDismissesKeyboard {
         // Determine the mode automatically based on the surrounding context
         case automatic

--- a/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+// swiftlint:disable identifier_name
 extension Binding {
     /// A way to create a new binding from another, as long as we can transform the values both ways
     /// - Parameters:

--- a/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension Binding {
+    /// A way to create a new binding from another, as long as we can transform the values both ways
+    /// - Parameters:
+    ///   - from: function that maps the binding `Value` to a `NewType`
+    ///   - to: function that maps a value of `NewType` to the original binding `Value`
+    /// - Returns: a binding that is a transformed interface for an original binding
+    func map<NewType>(from: @escaping (Value) -> NewType, to: @escaping (NewType) -> Value) -> Binding<NewType> {
+        .init(
+            get: { from(wrappedValue) },
+            set: { newValue in wrappedValue = to(newValue) }
+        )
+    }
+}


### PR DESCRIPTION
# Why?

There have been some generic stuff that should have been moved from the main app.

# What?

- Move back ported methods
- Move SATSGradient
- Add `Binding.map` extension

# Version Change

minor