### PR TITLE
Feature: modern error view

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -549,7 +549,8 @@
 /* Begin PBXShellScriptBuildPhase section */
 		9B83387825D30FFB0083B6D1 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			alwaysOutOfDate = 1;
+			buildActionMask = 12;
 			files = (
 			);
 			inputFileListPaths = (

--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -40,6 +40,7 @@
 		9B9D6D94261EF70500450E67 /* GradientDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9D6D93261EF70500450E67 /* GradientDemoView.swift */; };
 		9BA17B1026666D3600BDAA9C /* LoadingDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA17B0F26666D3600BDAA9C /* LoadingDemoView.swift */; };
 		9BB6E2AA25CC1B6A009A6CCD /* SwiftUIFontsDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB6E2A925CC1B6A009A6CCD /* SwiftUIFontsDemoView.swift */; };
+		9BCB6F0C294B209900202A52 /* ModernErrorDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCB6F0B294B209900202A52 /* ModernErrorDemoView.swift */; };
 		9BCEE85A26035CB2001C8692 /* InlineNoticeDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCEE85726035CB2001C8692 /* InlineNoticeDemoView.swift */; };
 		9BCEE85B26035CB2001C8692 /* ProgressLineDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCEE85926035CB2001C8692 /* ProgressLineDemoView.swift */; };
 		9BF417182681D25B00E708FD /* ScrollReaderDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF417172681D25B00E708FD /* ScrollReaderDemoView.swift */; };
@@ -96,6 +97,7 @@
 		9B9D6D93261EF70500450E67 /* GradientDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientDemoView.swift; sourceTree = "<group>"; };
 		9BA17B0F26666D3600BDAA9C /* LoadingDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingDemoView.swift; sourceTree = "<group>"; };
 		9BB6E2A925CC1B6A009A6CCD /* SwiftUIFontsDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIFontsDemoView.swift; sourceTree = "<group>"; };
+		9BCB6F0B294B209900202A52 /* ModernErrorDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernErrorDemoView.swift; sourceTree = "<group>"; };
 		9BCEE85726035CB2001C8692 /* InlineNoticeDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InlineNoticeDemoView.swift; sourceTree = "<group>"; };
 		9BCEE85926035CB2001C8692 /* ProgressLineDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressLineDemoView.swift; sourceTree = "<group>"; };
 		9BF417172681D25B00E708FD /* ScrollReaderDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollReaderDemoView.swift; sourceTree = "<group>"; };
@@ -389,6 +391,14 @@
 			path = Internal;
 			sourceTree = "<group>";
 		};
+		9BCB6F0A294B208600202A52 /* ModernErrorView */ = {
+			isa = PBXGroup;
+			children = (
+				9BCB6F0B294B209900202A52 /* ModernErrorDemoView.swift */,
+			);
+			path = ModernErrorView;
+			sourceTree = "<group>";
+		};
 		9BCEE85526035C83001C8692 /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -400,6 +410,7 @@
 				9B9D6D91261EF6E300450E67 /* GradientView */,
 				9BCEE85626035CB2001C8692 /* InlineNoticeView */,
 				9BA17B0E26666D2700BDAA9C /* LoadingView */,
+				9BCB6F0A294B208600202A52 /* ModernErrorView */,
 				9B8C11F226F23702007F5D0C /* NoticeView */,
 				9BCEE85826035CB2001C8692 /* ProgressLineView */,
 				57016DC0286349BA00874F53 /* RadioGroupView */,
@@ -593,6 +604,7 @@
 				9B7A4D5E25D2B42C0086EA4F /* UIKitDemoView.swift in Sources */,
 				9BCEE85A26035CB2001C8692 /* InlineNoticeDemoView.swift in Sources */,
 				9B78777925D68D9A00C69BB8 /* FontWeightPicker.swift in Sources */,
+				9BCB6F0C294B209900202A52 /* ModernErrorDemoView.swift in Sources */,
 				57016DC42863527200874F53 /* RadioGroupDemoView.swift in Sources */,
 				9B7C576125B876C400A3C9A7 /* DemoWrapperView.swift in Sources */,
 				9BB6E2AA25CC1B6A009A6CCD /* SwiftUIFontsDemoView.swift in Sources */,

--- a/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DemoApp/DemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "SATSType",
-        "repositoryURL": "https://github.com/healthfitnessnordic/SATSType-iOS.git",
+        "repositoryURL": "https://github.com/sats-group/SATSType-iOS.git",
         "state": {
           "branch": null,
           "revision": "3ba28b89b06c6e241cc6615219acb94ea9cdba0e",

--- a/DemoApp/DemoApp/Views/Components/ModernErrorView/ModernErrorDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/ModernErrorView/ModernErrorDemoView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ModernErrorDemoView: View {
+    var body: some View {
+        ModernErrorView(
+            viewData: .init(
+                title: "Ooops!",
+                message: "Something went terribly wrong",
+                canRetry: true
+            )
+        )
+        .navigationTitle("ErrorView")
+    }
+}
+
+struct ModernErrorDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        SATSFont.registerCustomFonts()
+        return ModernErrorDemoView()
+    }
+}

--- a/DemoApp/DemoApp/Views/ContentView.swift
+++ b/DemoApp/DemoApp/Views/ContentView.swift
@@ -30,6 +30,7 @@ struct ContentView: View {
                         NavigationLink("GradientView", destination: GradientDemoView())
                         NavigationLink("InlineNoticeView", destination: InlineNoticeDemoView())
                         NavigationLink("LoadingView", destination: LoadingDemoView())
+                        NavigationLink("ModernErrorView", destination: ModernErrorDemoView())
                         NavigationLink("NoticeView", destination: NoticeDemoView())
                     }
 

--- a/Sources/SATSCore/BasicComponents/SATSGradient/View-SATSGradient.swift
+++ b/Sources/SATSCore/BasicComponents/SATSGradient/View-SATSGradient.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct SATSGradient: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    let fallbackColor: Color
+
+    func body(content: Content) -> some View {
+        content.background(backgroundGradient)
+    }
+
+    var backgroundGradient: some View {
+        Group {
+            if colorScheme == .light {
+                LinearGradient(
+                    stops: [
+                        .init(color: .graphicalElements1.opacity(0), location: 0),
+                        .init(color: .graphicalElements1.opacity(1), location: 0.22),
+                        .init(color: .graphicalElements1.opacity(0), location: 0.65),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .opacity(0.2)
+                .background(Color.backgroundSecondary)
+            } else {
+                fallbackColor
+            }
+        }
+        .ignoresSafeArea()
+    }
+}
+
+public extension View {
+    func satsGradientBackground(fallbackColor: Color = .backgroundPrimary) -> some View {
+        modifier(SATSGradient(fallbackColor: fallbackColor))
+    }
+}

--- a/Sources/SATSCore/Components/ErrorView/ErrorView.swift
+++ b/Sources/SATSCore/Components/ErrorView/ErrorView.swift
@@ -29,6 +29,16 @@ public struct ErrorViewData {
     }
 }
 
+extension ErrorViewData {
+    public static func previewValue(
+        title: String? = "Something went wrong",
+        message: String = "This shouldn't have happened, contact support if the error persist.",
+        canRetry: Bool = true
+    ) -> Self {
+        .init(title: title, message: message, canRetry: canRetry)
+    }
+}
+
 /// A view which displays a title, message and retry button
 public class ErrorView: UIView {
     // MARK: Public properties

--- a/Sources/SATSCore/Components/ModernErrorView/ModernErrorView.swift
+++ b/Sources/SATSCore/Components/ModernErrorView/ModernErrorView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+public struct ModernErrorView: View {
+    let viewData: ErrorViewData
+    var onRetry: (() async -> Void)?
+
+    public init(viewData: ErrorViewData, onRetry: (() async -> Void)? = nil) {
+        self.viewData = viewData
+        self.onRetry = onRetry
+    }
+
+    public var body: some View {
+        VStack(spacing: .spacingL) {
+            Spacer()
+
+            icon
+
+            VStack(spacing: .spacingXS) {
+                errorTitle
+                errorMessage
+            }
+
+            Spacer()
+        }
+        .padding(.spacingXL)
+        .lineLimit(nil)
+        .foregroundColor(.onBackgroundPrimary)
+        .overlay { retryButtonContainer }
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: .infinity)
+        .satsGradientBackground()
+    }
+
+    var icon: some View {
+        Image(systemName: "xmark.circle")
+            .font(.system(size: 48))
+            .foregroundColor(.signalError)
+    }
+
+    @ViewBuilder var errorTitle: some View {
+        if let title = viewData.title {
+            Text(title)
+                .satsFont(.section, weight: .emphasis)
+        }
+    }
+
+    var errorMessage: some View {
+        Text(viewData.message)
+            .satsFont(.basic)
+    }
+
+    @ViewBuilder var retryButtonContainer: some View {
+        if viewData.canRetry {
+            VStack {
+                Spacer()
+
+                Button("Retry", action: retry)
+                    .satsButton(errorStyle, size: .large)
+                    .padding(.spacingL)
+            }
+        }
+    }
+
+    private func retry() {
+        Task { @MainActor in
+            await onRetry?()
+        }
+    }
+
+    private let errorStyle: SATSButton.Style = .init(
+        name: "ModernError",
+        titleColor: .onSignal,
+        titleColorDisabled: .onPrimaryDisabled,
+        backgroundColor: .signalError,
+        backgroundColorHighlighted: UIColor.signalError.withAlphaComponent(0.8),
+        backgroundColorDisabled: .primaryDisabled
+    )
+}
+
+struct ModernErrorView_Previews: PreviewProvider {
+    static var previews: some View {
+        SATSFont.registerCustomFonts()
+        return Group {
+            ModernErrorView(viewData: .previewValue())
+                .previewDisplayName("Full data")
+
+            ModernErrorView(viewData: .previewValue(title: nil))
+                .previewDisplayName("Only Message")
+
+            ModernErrorView(viewData: .previewValue(canRetry: false))
+                .previewDisplayName("No button")
+        }
+    }
+}

--- a/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Backport/Backport-ViewExtensions.swift
@@ -5,9 +5,20 @@ public extension View {
 }
 
 public extension Backport where Content: View {
+    /// This is needed as TextViews in iOS 16 have an extra background
+    @available(iOS, deprecated: 16, message: "This is a backported version that is not neeeded anymore")
+    @ViewBuilder func hideScrollContentBackground() -> some View {
+        if #available(iOS 16.0, *) {
+            content
+                .scrollContentBackground(.hidden)
+        } else {
+            content
+        }
+    }
+
     // here there will backported extensions when needed for iOS 16
-    @ViewBuilder
-    func scrollDismissesKeyboard(_ visibility: ScrollDismissesKeyboard) -> some View {
+    @available(iOS, deprecated: 16, message: "This is a backported version that is not neeeded anymore")
+    @ViewBuilder func scrollDismissesKeyboard(_ visibility: ScrollDismissesKeyboard) -> some View {
         if #available(iOS 16, *) {
             content
                 .scrollDismissesKeyboard(visibility.mode)
@@ -16,6 +27,7 @@ public extension Backport where Content: View {
         }
     }
 
+    @available(iOS, deprecated: 16, message: "This is a backported version that is not neeeded anymore")
     enum ScrollDismissesKeyboard {
         // Determine the mode automatically based on the surrounding context
         case automatic

--- a/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+// swiftlint:disable identifier_name
 extension Binding {
     /// A way to create a new binding from another, as long as we can transform the values both ways
     /// - Parameters:

--- a/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension Binding {
+    /// A way to create a new binding from another, as long as we can transform the values both ways
+    /// - Parameters:
+    ///   - from: function that maps the binding `Value` to a `NewType`
+    ///   - to: function that maps a value of `NewType` to the original binding `Value`
+    /// - Returns: a binding that is a transformed interface for an original binding
+    func map<NewType>(from: @escaping (Value) -> NewType, to: @escaping (NewType) -> Value) -> Binding<NewType> {
+        .init(
+            get: { from(wrappedValue) },
+            set: { newValue in wrappedValue = to(newValue) }
+        )
+    }
+}


### PR DESCRIPTION
> **Warning**: built on top of #126, review that one first

# Why?

Our existing `ErrorView` is built for UIKit, so when using it in SwiftUI we need to wrap it into a `SimpleViewRepresentable`, which is a bit unnecessary, when we mostly use SwiftUI in the main app.

Also, the design of that error view was a bit out of date and could use some love.

This `ModernErrorView` is intended as a full screen error component. Otherwise, use the `Notice` modifier instead.

# What?

- Add `ModernErrorView` + Demo view
- Add `ErrorViewData.previewValue` factory method

# Version Change

minor

# UI Changes

| ErrorView | ModernErrorView |
| --- | --- |
| <img width="565" alt="old" src="https://user-images.githubusercontent.com/167989/207825044-449b6766-731f-4189-b480-0b905781a393.png"> | <img width="565" alt="modern" src="https://user-images.githubusercontent.com/167989/207825064-2c7fa354-2ac2-417b-8916-ffef0e27957a.png"> |
