### PR TITLE
Improvement: custom async image modernization

### DIFF
--- a/DemoApp/DemoApp/Views/BasicComponents/CustomAsyncImageDemoView.swift
+++ b/DemoApp/DemoApp/Views/BasicComponents/CustomAsyncImageDemoView.swift
@@ -8,19 +8,25 @@ struct CustomAsyncDemoView: View {
 
     @State var imageViewData: ImageViewData = .image(Self.sampleImage)
     @State var showControls: Bool = true
+    @State var uuid = UUID()
+    @State var transitionDelay: TimeInterval = 2
+    var demoId: String { imageViewData.description + uuid.uuidString }
+
+    var formattedDelay: String {
+        String(format: "%.2f", transitionDelay)
+    }
 
     var body: some View {
         VStack {
-            Spacer()
-
-            CustomAsyncImage(imageViewData) { image in
+            CustomAsyncImage(imageViewData, transitionDelay: transitionDelay) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 200, height: 200)
                     .background(Color.red)
             }
+            .frame(size: 300)
             .background(Color.blue)
+            .padding(.top, 100)
             /*
              For demo purposes this is important.
 
@@ -35,7 +41,15 @@ struct CustomAsyncDemoView: View {
              we can achieve by tying the `id` of this view to the `imageViewData`.
              Then `imageViewData` changes we get a fresh copy of `CustomAsyncImage`
              */
-            .id(imageViewData)
+            .id(demoId)
+
+            if case .remote = imageViewData {
+                Button("Refetch Image", action: refetchRemoteImage)
+                    .buttonStyle(.borderedProminent)
+
+                Stepper("Transition Delay: \(formattedDelay)", value: $transitionDelay, in: 0 ... 5)
+                    .padding(.horizontal)
+            }
 
             Spacer()
         }
@@ -43,6 +57,10 @@ struct CustomAsyncDemoView: View {
         .navigationTitle("Custom Async Image")
         .overlay(controls)
         .background(Color.backgroundPrimary.ignoresSafeArea())
+    }
+
+    func refetchRemoteImage() {
+        uuid = UUID()
     }
 
     var controls: some View {

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
@@ -28,9 +28,14 @@ public struct CustomAsyncImage<Output: View>: View {
     ///
     /// - Parameters:
     ///   - state: the initial state for the async image
+    ///   - transitionDelay: (in Seconds) a way to artifically delay the transition for `.remote` images. Intended for debugging purposes only.
     ///   - transform: a closure that will be used to add modifiers to the view
-    public init(_ state: ImageViewData, transform: ((Image) -> Output)? = nil) {
-        self._viewModel = StateObject(wrappedValue: ImageViewModel(state: state))
+    public init(
+        _ state: ImageViewData,
+        transitionDelay: TimeInterval = 0,
+        transform: ((Image) -> Output)? = nil
+    ) {
+        self._viewModel = StateObject(wrappedValue: ImageViewModel(state: state, transitionDelay: transitionDelay))
         self.transform = transform
     }
 

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
@@ -24,7 +24,6 @@ import SwiftUI
 public struct CustomAsyncImage<Output: View>: View {
     @StateObject var viewModel: ImageViewModel
     let transform: ((Image) -> Output)?
-    let uuid: UUID = UUID()
 
     ///
     /// - Parameters:

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
@@ -51,6 +51,7 @@ public struct CustomAsyncImage<Output: View>: View {
                 }
             }
         }
+        .transition(.opacity)
         .task { await viewModel.loadImageIfNeeded() }
     }
 

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/CustomAsyncImage.swift
@@ -35,22 +35,23 @@ public struct CustomAsyncImage<Output: View>: View {
     }
 
     public var body: some View {
-        switch viewModel.state {
-        case .empty:
-            placeholder
-        case .remote:
-            placeholder
-                .onAppear(perform: viewModel.loadImage)
-        case .loading:
-            placeholder
-                .overlay(ProgressView())
-        case let .image(image):
-            if let transform = transform {
-                transform(image)
-            } else {
-                image
+        Group {
+            switch viewModel.state {
+            case .empty,
+                 .remote:
+                placeholder
+            case .loading:
+                placeholder
+                    .overlay(ProgressView())
+            case let .image(image):
+                if let transform = transform {
+                    transform(image)
+                } else {
+                    image
+                }
             }
         }
+        .task { await viewModel.loadImageIfNeeded() }
     }
 
     var placeholder: some View {

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageClient.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageClient.swift
@@ -7,11 +7,9 @@ import SwiftUI
 /// mechanisms is out of the scope of this library.
 public protocol ImageClient {
     /// Performs a network request to load the image given the URL
-    /// - Parameters:
-    ///   - url: the URL of the image to load
-    ///   - onCompletion: Closure that will return a result with a `SwiftUI.Image`
-    ///                   value if the operation was a success, an error otherwise
-    func loadImage(with url: URL, onCompletion: @escaping (Result<Image, Error>) -> Void)
+    /// - Parameter url: the URL of the image to load
+    /// - Returns: the SwiftUI Image for the given URL
+    func loadImage(with url: URL) async throws -> Image
 }
 
 /// Internal only type as a simple/default implementation of the `ImageClient` protocol.

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
@@ -10,19 +10,18 @@ class ImageViewModel: ObservableObject {
         self.state = state
     }
 
-    func loadImage() {
+    /// Loads and assign the remote image if needed,
+    /// basically, if the state is declared as `.remote(URL)`
+    @MainActor func loadImageIfNeeded() async {
         guard case let .remote(imageUrl) = state else { return }
 
         state = .loading
-        imageClient.loadImage(with: imageUrl) { [weak self] result in
-            DispatchQueue.main.async {
-                switch result {
-                case let .success(image):
-                    self?.state = .image(image)
-                case .failure:
-                    self?.state = .empty
-                }
-            }
+
+        do {
+            let image = try await imageClient.loadImage(with: imageUrl)
+            state = .image(image)
+        } catch {
+            state = .empty
         }
     }
 }

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
@@ -15,13 +15,13 @@ class ImageViewModel: ObservableObject {
     @MainActor func loadImageIfNeeded() async {
         guard case let .remote(imageUrl) = state else { return }
 
-        state = .loading
+        withAnimation { state = .loading }
 
         do {
             let image = try await imageClient.loadImage(with: imageUrl)
-            state = .image(image)
+            withAnimation { state = .image(image) }
         } catch {
-            state = .empty
+            withAnimation { state = .empty }
         }
     }
 }

--- a/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
+++ b/Sources/SATSCore/BasicComponents/CustomAsyncImage/ImageViewModel.swift
@@ -4,10 +4,13 @@ import SwiftUI
 class ImageViewModel: ObservableObject {
     @Published var state: ImageViewData = .empty
 
+    let transitionDelay: TimeInterval
+
     private var imageClient: ImageClient { Config.imageClient }
 
-    init(state: ImageViewData) {
+    init(state: ImageViewData, transitionDelay: TimeInterval = 0) {
         self.state = state
+        self.transitionDelay = transitionDelay
     }
 
     /// Loads and assign the remote image if needed,
@@ -19,9 +22,17 @@ class ImageViewModel: ObservableObject {
 
         do {
             let image = try await imageClient.loadImage(with: imageUrl)
+            await delay(for: transitionDelay)
             withAnimation { state = .image(image) }
         } catch {
+            await delay(for: transitionDelay)
             withAnimation { state = .empty }
+        }
+    }
+
+    func delay(for timeInterval: TimeInterval) async {
+        if #available(iOS 16.0, *) {
+            try? await Task.sleep(for: .seconds(timeInterval))
         }
     }
 }


### PR DESCRIPTION
# Why?

It's nice to use the `.task` so we can handle automatically the request cancellation,
also improving the feeling of the component by animating the state transitions

# What?

- Make the protocol `ImageClient` use _async/await_ instead of _closures_ to load images
- Use `.task` to load the image if needed for `CustomAsyncImage`
- Animate transitions between image states

# Version Change

**Breaking change**

The configuration protocol `ImageClient` changed, to use a `async` version instead of a closure based approach.

```diff
public protocol ImageClient {
-    func loadImage(with url: URL, onCompletion: @escaping (Result<Image, Error>) -> Void)
+    func loadImage(with url: URL) async throws -> Image
}
```

# Demo

https://user-images.githubusercontent.com/167989/218675454-8edec32e-16a7-47fc-a626-d02dafe2a313.mp4

## TODO

- [x] demo manipulating the loading states to show off the animation (also to ensure this works properly)