### PR TITLE
Feature: `SATSCell.BasicCell`

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		57016DC42863527200874F53 /* RadioGroupDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57016DC32863527200874F53 /* RadioGroupDemoView.swift */; };
 		9B00E27325B9AE2600533641 /* SATSCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9B00E27225B9AE2600533641 /* SATSCore */; };
 		9B00E29725B9D12900533641 /* Demo.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B00E29625B9D12900533641 /* Demo.xcassets */; };
+		9B1CA89F297EAB4B006A63D1 /* SATSCellDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CA89E297EAB4B006A63D1 /* SATSCellDemoView.swift */; };
 		9B2BFBDA25B719AD00383193 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BFBD925B719AD00383193 /* DemoApp.swift */; };
 		9B2BFBDC25B719AD00383193 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BFBDB25B719AD00383193 /* ContentView.swift */; };
 		9B2BFBDE25B719AD00383193 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B2BFBDD25B719AD00383193 /* Assets.xcassets */; };
@@ -65,6 +66,7 @@
 		28D0A16627A93846001374D2 /* DatePickerDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerDemoView.swift; sourceTree = "<group>"; };
 		57016DC32863527200874F53 /* RadioGroupDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioGroupDemoView.swift; sourceTree = "<group>"; };
 		9B00E29625B9D12900533641 /* Demo.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Demo.xcassets; sourceTree = "<group>"; };
+		9B1CA89E297EAB4B006A63D1 /* SATSCellDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATSCellDemoView.swift; sourceTree = "<group>"; };
 		9B2BFBD625B719AD00383193 /* DemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B2BFBD925B719AD00383193 /* DemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoApp.swift; sourceTree = "<group>"; };
 		9B2BFBDB25B719AD00383193 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -243,6 +245,7 @@
 				9BFEDCC825CC1F780010A3F6 /* SATSButtonDemoView.swift */,
 				9BF8D1F82679E4A000D4430B /* SATSButtonSwiftUIDemoView.swift */,
 				9B7C575C25B875C500A3C9A7 /* SATSLabelDemoView.swift */,
+				9B1CA89E297EAB4B006A63D1 /* SATSCellDemoView.swift */,
 			);
 			path = BasicComponents;
 			sourceTree = "<group>";
@@ -596,6 +599,7 @@
 				28D0A16727A93846001374D2 /* DatePickerDemoView.swift in Sources */,
 				9BFBDEF726DCC93C0066F1C8 /* TabSelectionDemoView.swift in Sources */,
 				9B9A53A0267CC51500AE9266 /* CustomAsyncImageDemoView.swift in Sources */,
+				9B1CA89F297EAB4B006A63D1 /* SATSCellDemoView.swift in Sources */,
 				9B4083BD261DE66D00A3A718 /* TopBarDemoView.swift in Sources */,
 				9BCEE85B26035CB2001C8692 /* ProgressLineDemoView.swift in Sources */,
 				9B7A4D6125D2B9C30086EA4F /* TreatmentsDemoView.swift in Sources */,

--- a/DemoApp/DemoApp/Views/BasicComponents/SATSCellDemoView.swift
+++ b/DemoApp/DemoApp/Views/BasicComponents/SATSCellDemoView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct SATSCellDemoView: View {
+    var body: some View {
+        VStack {
+            VStack(spacing: 0) {
+                cell(iconName: nil, title: "Rewards")
+                cell(iconName: "trophy", title: "Rewards")
+                cell(iconName: "trophy", title: "Rewards", subtitle: "Sample subtitlte")
+                    .foregroundColor(.red)
+                cell(action: { Image(systemName: "questionmark.circle") })
+
+                cell(
+                    iconName: "person.text.rectangle",
+                    title: "My page",
+                    subtitle: "Upgrade, downgrade, cancel",
+                    action: { Image(systemName: "square.and.arrow.up") }
+                )
+                .foregroundColor(.action)
+
+                cell(accessory: { Text("Gold") })
+
+                cell(
+                    iconName: "xmark.circle",
+                    title: "Log out",
+                    action: { EmptyView() },
+                    includeDivider: false
+                )
+                .foregroundColor(.signalError)
+            }
+            .cornerRadius(.cornerRadiusS)
+            .shadow(color: Color.black.opacity(0.2), radius: 6)
+
+            Spacer()
+        }
+        .padding()
+        .background(Color.backgroundPrimary)
+        .navigationTitle("SATSCell")
+    }
+
+    func cell<AccessoryView: View, ActionView: View>(
+        iconName: String? = "trophy",
+        title: String = "Rewards",
+        subtitle: String? = nil,
+        @ViewBuilder accessory: () -> AccessoryView = EmptyView.init,
+        @ViewBuilder action: () -> ActionView = SATSCell.SystemChevron.init,
+        includeDivider: Bool = true
+    ) -> some View {
+        SATSCell.BasicCell(
+            icon: {
+                if let iconName {
+                    SATSCell.SystemIcon(iconName: iconName)
+                } else {
+                    SATSCell.NoIcon()
+                }
+            },
+            title: title,
+            subtitle: subtitle,
+            accessory: accessory,
+            action: action,
+            includeDivider: includeDivider,
+            onClick: nil
+        )
+    }
+}
+
+struct SATSCellDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            SATSCellDemoView()
+        }
+    }
+}

--- a/DemoApp/DemoApp/Views/ContentView.swift
+++ b/DemoApp/DemoApp/Views/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
                 Section(header: Text("SwiftUI Basics")) {
                     NavigationLink("Button Styles", destination: SATSButtonSwftUIDemoView())
                     NavigationLink("Custom Async Image", destination: CustomAsyncDemoView())
+                    NavigationLink("SATSCell", destination: SATSCellDemoView())
                 }
 
                 Section(header: Text("Components")) {

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "SATSType",
-        "repositoryURL": "git@github.com:healthfitnessnordic/SATSType-iOS.git",
+        "repositoryURL": "https://github.com/sats-group/SATSType-iOS.git",
         "state": {
           "branch": null,
           "revision": "7226330dc2c014d49e9b126fc67e8ddc0b0b62e9",

--- a/Sources/SATSCore/BasicComponents/SATSCell/SATSCell-BasicCell.swift
+++ b/Sources/SATSCore/BasicComponents/SATSCell/SATSCell-BasicCell.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+public extension SATSCell {
+    /// A button to implement a custom table-view cell
+    struct BasicCell<IconView: View, AccessoryView: View, ActionView: View>: View {
+        @ViewBuilder var icon: IconView
+        var title: String
+        var subtitle: String?
+        @ViewBuilder var accessory: AccessoryView
+        @ViewBuilder var action: ActionView
+        var includeDivider: Bool = true
+        var onClick: (() -> Void)?
+
+        public init(
+            @ViewBuilder icon: () -> IconView = SATSCell.NoIcon.init,
+            title: String,
+            subtitle: String? = nil,
+            @ViewBuilder accessory: () -> AccessoryView = EmptyView.init,
+            @ViewBuilder action: () -> ActionView = SATSCell.SystemChevron.init,
+            includeDivider: Bool = true,
+            onClick: (() -> Void)? = nil
+        ) {
+            self.icon = icon()
+            self.title = title
+            self.subtitle = subtitle
+            self.accessory = accessory()
+            self.action = action()
+            self.includeDivider = includeDivider
+            self.onClick = onClick
+        }
+
+        public var body: some View {
+            Button(action: { onClick?() }) {
+                HStack(alignment: .center, spacing: .spacingS) {
+                    icon
+                        .padding(.leading, .spacingS)
+
+                    VStack(spacing: 0) {
+                        HStack(spacing: .spacingXS) {
+                            VStack(alignment: .leading, spacing: .spacingXXS) {
+                                Text(title)
+                                    .satsFont(.basic)
+
+                                subtitleLabel
+                            }
+                            Spacer()
+                            accessory
+                            action
+                        }
+                        .padding(.trailing, .spacingS)
+                        .padding(.vertical, .spacingM)
+
+                        divider
+                    }
+                }
+                .contentShape(Rectangle())
+                .background(Color.backgroundSurfacePrimary)
+            }
+            .buttonStyle(.plain)
+        }
+
+        @ViewBuilder var subtitleLabel: some View {
+            if let subtitle {
+                Text(subtitle)
+                    .satsFont(.small)
+            }
+        }
+
+        @ViewBuilder var divider: some View {
+            if includeDivider {
+                Divider()
+                    .background(Color.border)
+            }
+        }
+    }
+}

--- a/Sources/SATSCore/BasicComponents/SATSCell/SATSCell-BasicCell.swift
+++ b/Sources/SATSCore/BasicComponents/SATSCell/SATSCell-BasicCell.swift
@@ -47,7 +47,7 @@ public extension SATSCell {
                             accessory
                             action
                         }
-                        .padding(.trailing, .spacingS)
+                        .padding(.trailing, .spacingM)
                         .padding(.vertical, .spacingM)
 
                         divider

--- a/Sources/SATSCore/BasicComponents/SATSCell/SATSCell.swift
+++ b/Sources/SATSCore/BasicComponents/SATSCell/SATSCell.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+public enum SATSCell {}
+
+// MARK: Cell - Icon Views
+
+public extension SATSCell {
+    /// SF Symbol base icon
+    struct SystemIcon: View {
+        var iconName: String
+
+        public init(iconName: String) {
+            self.iconName = iconName
+        }
+
+        public var body: some View {
+            Image(systemName: iconName)
+                .frame(minWidth: 28)
+        }
+    }
+
+    /// Placeholder for no icon
+    struct NoIcon: View {
+        public init() {}
+
+        public var body: some View {
+            Color.clear.frame(size: 0)
+        }
+    }
+}
+
+// MARK: Cell - Action Views
+
+public extension SATSCell {
+    /// SF Symbol for chevrons
+    struct SystemChevron: View {
+        public init() {}
+
+        public var body: some View {
+            Image(systemName: "chevron.right")
+        }
+    }
+}


### PR DESCRIPTION
# Why?

We tend to not use `List` in the main app.
We tend to favor custom made list for most use cases.
For that, we needed a way to generally create custom table cells.
Now, there is a lot of common and optional elements for the cell

# What?


Add `SATSCell.BasicCell` with its demo view.

The design of the SATSCell.BasicCell element can be found in https://github.com/sats-group/SATSCore-iOS/commit/24bc78698c5b51db98b2674dfe71184fa6e149ed

# Version Change

minor

# Demo

The `SATSCell.BasicCell` can be stylized as follows

| Light | Dark |
|:----:|:-----:|
| <img width="565" alt="Screenshot 2023-01-23 at 13 07 38" src="https://user-images.githubusercontent.com/167989/214035957-3943cb43-bb2e-4198-b281-a6cd93a7b555.png"> | <img width="565" alt="Screenshot 2023-01-23 at 13 07 40" src="https://user-images.githubusercontent.com/167989/214035982-b69b4c5b-7a62-49f6-b9c1-f4ba8d9e45b0.png"> |
