### PR TITLE
Improvement: rename `ScrollReaderView` to `ScrollViewOffsetReader`

### DIFF
--- a/DemoApp/DemoApp/Views/Components/ScrollReaderView/ScrollReaderDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/ScrollReaderView/ScrollReaderDemoView.swift
@@ -4,7 +4,7 @@ struct ScrollReaderDemoView: View {
     @State var scrollValue: CGFloat = 0
 
     var body: some View {
-        ScrollReaderView(scrollValue: $scrollValue) {
+        ScrollViewOffsetReader(scrollValue: $scrollValue) {
             Rectangle()
                 .foregroundColor(.shimmer)
                 .overlay(

--- a/DemoApp/DemoApp/Views/Components/ScrollReaderView/ScrollReaderDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/ScrollReaderView/ScrollReaderDemoView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct ScrollReaderDemoView: View {
+struct ScrollViewOffsetReaderDemoView: View {
     @State var scrollValue: CGFloat = 0
 
     var body: some View {
@@ -28,14 +28,14 @@ struct ScrollReaderDemoView: View {
                     .background(Color.blue.opacity(0.2))
             }
         )
-        .navigationTitle("ScrollReaderDemoView")
+        .navigationTitle("ScrollViewOffsetReaderDemoView")
     }
 }
 
-struct ScrollReaderDemoView_Previews: PreviewProvider {
+struct ScrollViewOffsetReaderDemoView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            ScrollReaderDemoView()
+            ScrollViewOffsetReaderDemoView()
         }
     }
 }

--- a/DemoApp/DemoApp/Views/ContentView.swift
+++ b/DemoApp/DemoApp/Views/ContentView.swift
@@ -40,7 +40,7 @@ struct ContentView: View {
                         NavigationLink("ProgressLineView", destination: ProgressLineDemoView())
                         NavigationLink("RoundLoadingView", destination: RoundLoadingDemoView())
                         NavigationLink("ScoreView", destination: ScoreDemoView())
-                        NavigationLink("ScrollReaderView", destination: ScrollReaderDemoView())
+                        NavigationLink("ScrollViewOffsetReader", destination: ScrollViewOffsetReaderDemoView())
                         NavigationLink("TabSelectionView", destination: TabSelectionDemoView())
                         NavigationLink("TopBar", destination: TopBarDemoView())
                         NavigationLink("RadioGroup", destination: RadioGroupDemoView())

--- a/Sources/SATSCore/Components/ScrollReaderView/ScrollViewOffsetReader.swift
+++ b/Sources/SATSCore/Components/ScrollReaderView/ScrollViewOffsetReader.swift
@@ -10,6 +10,7 @@ import SwiftUI
   Original solution found in: https://developer.apple.com/forums/thread/650312
   */
 public struct ScrollViewOffsetReader<Content: View>: View {
+    let axis: Axis.Set
     let content: Content
     let showsIndicators: Bool
     @Binding var scrollValue: CGFloat
@@ -17,26 +18,27 @@ public struct ScrollViewOffsetReader<Content: View>: View {
     private let namespace: String = "scrollReader"
 
     public init(
+        _ axis: Axis.Set = .vertical,
         scrollValue: Binding<CGFloat>,
         showsIndicators: Bool = true,
         @ViewBuilder _ content: () -> Content
     ) {
+        self.axis = axis
         self._scrollValue = scrollValue
         self.showsIndicators = showsIndicators
         self.content = content()
     }
 
     public var body: some View {
-        ScrollView(showsIndicators: showsIndicators) {
+        ScrollView(axis, showsIndicators: showsIndicators) {
             ZStack {
                 content
 
                 GeometryReader { proxy in
-                    let offset = proxy.frame(in: .named(namespace)).minY
                     Color.clear
                         .preference(
                             key: ScrollViewOffsetPreferenceKey.self,
-                            value: offset
+                            value: offset(in: proxy)
                         )
                 }
             }
@@ -47,6 +49,15 @@ public struct ScrollViewOffsetReader<Content: View>: View {
         }
     }
 
+    private func offset(in proxy: GeometryProxy) -> CGFloat {
+        let frame = proxy.frame(in: .named(namespace))
+
+        if axis == .horizontal {
+            return frame.minX
+        } else {
+            return frame.minY
+        }
+    }
 }
 
 private struct ScrollViewOffsetPreferenceKey: PreferenceKey {

--- a/Sources/SATSCore/Components/ScrollReaderView/ScrollViewOffsetReader.swift
+++ b/Sources/SATSCore/Components/ScrollReaderView/ScrollViewOffsetReader.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
   Original solution found in: https://developer.apple.com/forums/thread/650312
   */
-public struct ScrollReaderView<Content: View>: View {
+public struct ScrollViewOffsetReader<Content: View>: View {
     let content: Content
     let showsIndicators: Bool
     @Binding var scrollValue: CGFloat
@@ -46,6 +46,7 @@ public struct ScrollReaderView<Content: View>: View {
             scrollValue = value
         }
     }
+
 }
 
 private struct ScrollViewOffsetPreferenceKey: PreferenceKey {


### PR DESCRIPTION
# Why?

SwiftUI has type called `ScrollViewReader` so our `ScrollReaderView` was not a good name.

# What?

- Update the name of the _public_ type and the demo
- Add the capability to use `ScrollViewOffsetReader` in horizontal mode as well

# Version Change

⚠️ **Breaking change**

Users of the library just need to replace calls to `ScrollViewReader` with `ScrollViewOffsetReader`. The rest of the API stays the same