### PR TITLE
Improvement: Notice - make message required and title optional

### DIFF
--- a/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/NoticeView/NoticeDemoView.swift
@@ -1,16 +1,9 @@
-//
-//  ErrorNoticeView.swift
-//  DemoApp
-//
-//  Created by Felipe Espinoza on 24/06/2021.
-//
-
 import SwiftUI
 
 struct NoticeDemoView: View {
     @State var notice: Notice?
 
-    @State var includeSubtitle: Bool = true
+    @State var includeTitle: Bool = true
     @State var autoDismiss: Bool = false
     @State var edgeTop: Bool = true
     @State var withAction: Bool = true
@@ -39,7 +32,7 @@ struct NoticeDemoView: View {
 
     @ViewBuilder var noticeEditor: some View {
         VStack {
-            Toggle("Include Subtitle?", isOn: $includeSubtitle)
+            Toggle("Include title?", isOn: $includeTitle)
             Toggle("Auto dismiss?", isOn: $autoDismiss)
             Toggle("Top Edge?", isOn: $edgeTop)
             if style == .error {
@@ -83,42 +76,42 @@ struct NoticeDemoView: View {
     // by using the `.success`, `.warning` and `.error`
     // factory methods which contain sensible defaults
     private func createNotice() -> Notice {
-        let subtitle = includeSubtitle ? "Subtitle text" : nil
+        let title = includeTitle ? "Title text" : nil
 
         switch (style, withAction) {
         case (.info, _):
             return Notice.info(
-                title: "Sample info notice",
-                explanation: subtitle,
+                title: title,
+                message: "Sample info notice",
                 autoDismiss: autoDismiss
             )
 
         case (.success, _):
             return Notice.success(
-                title: "Sample success notice",
-                explanation: subtitle,
+                title: title,
+                message: "Sample success notice",
                 autoDismiss: autoDismiss
             )
 
         case (.warning, _):
             return Notice.warning(
-                title: "Sample warning notice",
-                explanation: subtitle,
+                title: title,
+                message: "Sample warning notice",
                 autoDismiss: autoDismiss
             )
 
         case (.error, true):
             return Notice.error(
-                title: "Sample error notice",
-                explanation: subtitle,
+                title: title,
+                message: "Sample error notice",
                 actionTitle: "Action",
                 action: { print("on action!") }
             )
 
         case (.error, false):
             return Notice.error(
-                title: "Sample error notice",
-                explanation: subtitle,
+                title: title,
+                message: "Sample warning notice",
                 autoDismiss: autoDismiss
             )
         }
@@ -167,25 +160,25 @@ struct ErrorNoticeView_Previews: PreviewProvider {
 
 extension Notice {
     static let sampleError = Notice.error(
-        title: "This is a sample error"
+        message: "This is a sample error"
     )
 
     static let sampleErrorWithAction = Notice.error(
-        title: "This is a sample error",
+        message: "This is a sample error",
         actionTitle: "Action",
         action: { print("Sample") }
     )
 
     static let sampleSuccess = Notice.success(
         title: "Your operation was succesful",
-        explanation: "everything is awesome!"
+        message: "everything is awesome!"
     )
 
     static let sampleWarning = Notice.warning(
-        title: "You should be careful about this!"
+        message: "You should be careful about this!"
     )
 
     static let sampleInfo = Notice.info(
-        title: "We have a new notice style"
+        message: "We have a new notice style"
     )
 }

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -6,8 +6,8 @@ import SwiftUI
 /// is enough
 public struct Notice {
     public let icon: Image?
-    public let title: String
-    public let explanation: String?
+    public let title: String?
+    public let message: String
     public let autoDismiss: Bool
     public let tintColor: Color
     public let hapticType: UINotificationFeedbackGenerator.FeedbackType?
@@ -16,8 +16,8 @@ public struct Notice {
 
     public init(
         icon: Image? = nil,
-        title: String,
-        explanation: String? = nil,
+        title: String? = nil,
+        message: String,
         autoDismiss: Bool = true,
         tintColor: Color,
         hapticType: UINotificationFeedbackGenerator.FeedbackType? = nil,
@@ -26,7 +26,7 @@ public struct Notice {
     ) {
         self.icon = icon
         self.title = title
-        self.explanation = explanation
+        self.message = message
         self.autoDismiss = autoDismiss
         self.tintColor = tintColor
         self.hapticType = hapticType
@@ -36,16 +36,16 @@ public struct Notice {
 
     /// Creates an error notice data struct
     /// - Parameters:
-    ///   - title: required title of the error
-    ///   - explanation: (optional) explanation of the error
+    ///   - title: (optional) title of the error
+    ///   - message: required message of the error
     ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
     ///   - actionTitle: (optional) a title for a notice button
     ///   - action: (optional) an action to perform when pressing the action button
     /// - Returns: a `Notice` instance that can be used with `NoticeView`
     public static func error(
-        title: String,
-        explanation: String? = nil,
+        title: String? = nil,
+        message: String,
         autoDismiss: Bool = true,
         includeHaptic: Bool = true,
         actionTitle: String? = nil,
@@ -54,7 +54,7 @@ public struct Notice {
         Notice(
             icon: Image(systemName: "xmark.octagon"),
             title: title,
-            explanation: explanation,
+            message: message,
             autoDismiss: autoDismiss,
             tintColor: .signalError,
             hapticType: includeHaptic ? .error : nil,
@@ -65,16 +65,16 @@ public struct Notice {
 
     /// Create a error notice with action options
     /// - Parameters:
-    ///   - title: required title of the error
-    ///   - explanation: (optional) explanation of the error
+    ///   - title: (optional) title of the error
+    ///   - message: required message of the error
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
     ///   - actionTitle: title for the action button
     ///   - action: callback when the action button is tapped
     /// - Returns: returns a error `Notice` that won't autodismiss that allows to action
     ///            an operation that caused an error
     public static func error(
-        title: String,
-        explanation: String? = nil,
+        title: String? = nil,
+        message: String,
         includeHaptic: Bool = true,
         actionTitle: String,
         action: @escaping () -> Void
@@ -82,7 +82,7 @@ public struct Notice {
         Notice(
             icon: Image(systemName: "xmark.octagon"),
             title: title,
-            explanation: explanation,
+            message: message,
             autoDismiss: false,
             tintColor: .signalError,
             hapticType: includeHaptic ? .error : nil,
@@ -93,21 +93,21 @@ public struct Notice {
 
     /// Creates a warning notice data struct
     /// - Parameters:
-    ///   - title: required title of the warning
-    ///   - explanation: (optional) explanation of the warning
+    ///   - title: (optional) title of the warning
+    ///   - message: required message of the warning
     ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
     /// - Returns: a `Notice` instance that can be used with `NoticeView`
     public static func warning(
-        title: String,
-        explanation: String? = nil,
+        title: String? = nil,
+        message: String,
         autoDismiss: Bool = true,
         includeHaptic: Bool = true
     ) -> Notice {
         Notice(
             icon: Image(systemName: "exclamationmark.triangle"),
             title: title,
-            explanation: explanation,
+            message: message,
             autoDismiss: autoDismiss,
             tintColor: .signalWarning,
             hapticType: includeHaptic ? .warning : nil
@@ -116,21 +116,21 @@ public struct Notice {
 
     /// Creates a success notice data struct
     /// - Parameters:
-    ///   - title: required title of the notice
-    ///   - explanation: (optional) explanation of the notice
+    ///   - title: (optional) title of the notice
+    ///   - message: required message of the notice
     ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
     /// - Returns: a `Notice` instance that can be used with `NoticeView`
     public static func success(
-        title: String,
-        explanation: String? = nil,
+        title: String? = nil,
+        message: String,
         autoDismiss: Bool = true,
         includeHaptic: Bool = true
     ) -> Notice {
         Notice(
             icon: Image(systemName: "checkmark.circle"),
             title: title,
-            explanation: explanation,
+            message: message,
             autoDismiss: autoDismiss,
             tintColor: .signalSuccess,
             hapticType: includeHaptic ? .success : nil
@@ -139,21 +139,21 @@ public struct Notice {
 
     /// Creates a info notice data struct
     /// - Parameters:
-    ///   - title: required title of the notice
-    ///   - explanation: (optional) explanation of the notice
+    ///   - title: (optional) title of the notice
+    ///   - message: required message of the notice
     ///   - autoDismiss: (default `true`) configures the auto dismiss behavior of a notice
     ///   - includeHaptic: (default `true`) enable or disable the haptic when showing this notice
     /// - Returns: a `Notice` instance that can be used with `NoticeView`
     public static func info(
-        title: String,
-        explanation: String? = nil,
+        title: String? = nil,
+        message: String,
         autoDismiss: Bool = true,
         includeHaptic: Bool = true
     ) -> Notice {
         Notice(
             icon: Image(systemName: "info.circle"),
             title: title,
-            explanation: explanation,
+            message: message,
             autoDismiss: autoDismiss,
             tintColor: .graphicalElements1,
             hapticType: includeHaptic ? .success : nil

--- a/Sources/SATSCore/Components/NoticeView/NoticeView.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeView.swift
@@ -55,13 +55,14 @@ public struct NoticeView: View {
 
     var message: some View {
         VStack(alignment: .leading, spacing: .spacingXXXS) {
-            Text(notice.title)
-                .satsFont(.basic, weight: .emphasis)
-
-            if let explanation = notice.explanation {
-                Text(explanation)
-                    .satsFont(.basic, weight: .medium)
+            if let title = notice.title {
+                Text(title)
+                    .satsFont(.basic, weight: .emphasis)
             }
+
+            Text(notice.message)
+                .satsFont(.basic, weight: .medium)
+
         }
         .foregroundColor(.onSurfaceSecondary)
     }


### PR DESCRIPTION
# Why?

- Make the properties of the notice similar to `ErrorViewData` in Sats-MemberApp. Therefore, rename `explanation` to `message`
- The current notice has an optional `explanation` and a required `title`. We can argue that a title without content doesn't make sense, but an explanation makes sense without a title.

# What?

- Rename `explanation` to `message` as requierd property.
- `title`is now optional.

# Version Change

breaking change

# UI Changes

| Before | After |
|:----:|:----:|
|![image](https://user-images.githubusercontent.com/9019310/225064302-bbed4026-887d-4e42-97f6-3f1105283e32.png)|![image](https://user-images.githubusercontent.com/9019310/225063600-6630eeb9-a1bf-4ece-814d-688bb6beffa4.png)|