### PR TITLE
Feature: view sizeClassHeight modifier

### DIFF
--- a/Sources/SATSCore/BasicComponents/SATSCell/SATSCell-BasicCell.swift
+++ b/Sources/SATSCore/BasicComponents/SATSCell/SATSCell-BasicCell.swift
@@ -10,6 +10,7 @@ public extension SATSCell {
         @ViewBuilder var action: ActionView
         var includeDivider: Bool = true
         var onClick: (() -> Void)?
+        let backgroundColor: Color
 
         public init(
             @ViewBuilder icon: () -> IconView = SATSCell.NoIcon.init,
@@ -18,7 +19,8 @@ public extension SATSCell {
             @ViewBuilder accessory: () -> AccessoryView = EmptyView.init,
             @ViewBuilder action: () -> ActionView = SATSCell.SystemChevron.init,
             includeDivider: Bool = true,
-            onClick: (() -> Void)? = nil
+            onClick: (() -> Void)? = nil,
+            backgroundColor: Color = .backgroundSurfacePrimary
         ) {
             self.icon = icon()
             self.title = title
@@ -27,6 +29,7 @@ public extension SATSCell {
             self.action = action()
             self.includeDivider = includeDivider
             self.onClick = onClick
+            self.backgroundColor = backgroundColor
         }
 
         public var body: some View {
@@ -54,7 +57,7 @@ public extension SATSCell {
                     }
                 }
                 .contentShape(Rectangle())
-                .background(Color.backgroundSurfacePrimary)
+                .background(backgroundColor)
             }
             .buttonStyle(.plain)
         }

--- a/Sources/SATSCore/Extensions/SwiftUI/ViewModifiers/ImageSizeClassHeightModifier.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/ViewModifiers/ImageSizeClassHeightModifier.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+public extension View {
+    /// Intended mostly for images, it will use a given height in `horizontalSizeClass` `compact`
+    /// and another value for the `regular` case
+    /// - Parameters:
+    ///   - compact: height for the compact horizontal case
+    ///   - regular: height for the regular horizontal case
+    func sizeClassHeight(compact: CGFloat = 240, regular: CGFloat = 360) -> some View {
+        modifier(ImageSizeClassHeightModifier(compactHeight: compact, regularHeigth: regular))
+    }
+}
+
+private struct ImageSizeClassHeightModifier: ViewModifier {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    let compactHeight: CGFloat
+    let regularHeigth: CGFloat
+
+    init(compactHeight: CGFloat, regularHeigth: CGFloat) {
+        self.compactHeight = compactHeight
+        self.regularHeigth = regularHeigth
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .frame(height: horizontalSizeClass == .regular ? regularHeigth : compactHeight)
+    }
+}


### PR DESCRIPTION
# Why?

A convenience modifier to give a constant height that applies for the given horizontal size class,

then we can specify for example:

- 240 pts for the compact horizontal size class
- 360 pts for the regular horizontal size class

# What?

- Add `View.sizeClassHeight` modifier
- Allow setting the background color for SATSCell.BasicCell

# Version Change

minor