### PR TITLE
Fix: dynamic type for swift UI

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -471,8 +471,9 @@
 		9B2BFBCE25B719AC00383193 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1230;
+				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					9B2BFBD525B719AD00383193 = {
 						CreatedOnToolsVersion = 12.3;

--- a/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DemoApp/DemoApp/Utils/DemoWrapperView.swift
+++ b/DemoApp/DemoApp/Utils/DemoWrapperView.swift
@@ -5,12 +5,7 @@ import UIKit
 struct DemoWrapperView<DemoView: UIView>: UIViewRepresentable {
     let view: DemoView
 
-    init(view: DemoView) {
-        self.view = view
-    }
-
     func makeUIView(context: Context) -> DemoView { view }
-
     func updateUIView(_ uiView: DemoView, context: Context) {}
 }
 
@@ -18,11 +13,6 @@ struct DemoWrapperView<DemoView: UIView>: UIViewRepresentable {
 struct DemoWrapperViewController<DemoViewController: UIViewController>: UIViewControllerRepresentable {
     let viewController: DemoViewController
 
-    init(viewController: DemoViewController) {
-        self.viewController = viewController
-    }
-
     func makeUIViewController(context: Context) -> DemoViewController { viewController }
-
     func updateUIViewController(_ view: DemoViewController, context: Context) {}
 }

--- a/DemoApp/DemoApp/Views/Components/BannerNotice/BannerNoticeDemoView.swift
+++ b/DemoApp/DemoApp/Views/Components/BannerNotice/BannerNoticeDemoView.swift
@@ -7,14 +7,14 @@ struct BannerNoticeDemoView: View {
             BannerNotice(
                 viewData: .init(
                     message: "Banner with action and icon",
-                    action: .init(title: "Action", icon: Image(systemName: "link"), onClick: { })
+                    action: .init(title: "Action", icon: Image(systemName: "link"), onClick: {})
                 )
             )
 
             BannerNotice(
                 viewData: .init(
                     message: "Banner with action without icon",
-                    action: .init(title: "Action", onClick: { })
+                    action: .init(title: "Action", onClick: {})
                 )
             )
 

--- a/Sources/SATSCore/Components/BannerNotice/BannerNotice.swift
+++ b/Sources/SATSCore/Components/BannerNotice/BannerNotice.swift
@@ -14,7 +14,7 @@ public extension BannerNoticeViewData {
     struct Action {
         let title: String
         let icon: Image?
-        let onClick: (() -> Void)
+        let onClick: () -> Void
 
         public init(title: String, icon: Image? = nil, onClick: @escaping () -> Void) {
             self.title = title

--- a/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
@@ -15,6 +15,22 @@ public extension Text {
 
 public extension Font {
     static func satsFont(_ style: SATSFont.TextStyle, weight: SATSFont.Weight = .default) -> Font {
-        Font(SATSFont.font(style: style, weight: weight))
+        Font.custom(weight.font.name, size: style.size, relativeTo: .from(style.nativeStyle))
+    }
+}
+
+extension Font.TextStyle {
+    /// Convert an UIKit text style into a SwiftUI one
+    static func from(_ uiFontStyle: UIFont.TextStyle) -> Self {
+        switch uiFontStyle {
+        case .title1: return .title
+        case .title2: return .title2
+        case .title3: return .title3
+        case .callout: return .callout
+        case .footnote: return .footnote
+        case .subheadline: return .subheadline
+        default:
+            return .body
+        }
     }
 }

--- a/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
@@ -14,3 +14,4 @@ extension Binding {
         )
     }
 }
+// swiftlint:enable identifier_name

--- a/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Binding-Extensions.swift
@@ -14,4 +14,5 @@ extension Binding {
         )
     }
 }
+
 // swiftlint:enable identifier_name


### PR DESCRIPTION
# Why?

SATSFont.font internally uses `UIFontMetrics` to determine the sizes of
the font adjusted to font families for dynamic type.

**But** since this lives in UIKit-land, this value doens't get
recomputed when the environment changes (in a SwiftUI context), but only
when the UITraitCollection of a view controller changes.

In the case of SwiftUI previews, only the environment changes for
previews, that's the reason we were not seeing the changes in font size
when we did the "show accessibility variants" in previews.

Now, by using `Font.custom` the values do get recomputed when the
environment's `dynamicTypeSize` changes.

# Version Change

patch