### PR TITLE
Experiment: SF Font

### DIFF
--- a/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
@@ -2,14 +2,35 @@ import SwiftUI
 
 public extension View {
     @ViewBuilder
-    func satsFont(_ style: SATSFont.TextStyle, weight: SATSFont.Weight = .default) -> some View {
-        font(.satsFont(style, weight: weight))
+    func satsFont(
+        _ style: SATSFont.TextStyle,
+        weight: SATSFont.Weight = .default,
+        design: Font.Design = .default
+    ) -> some View {
+        modifier(FontContainerModifier(style: style, weight: weight, design: design))
     }
 }
 
 public extension Text {
     func satsFont(_ style: SATSFont.TextStyle, weight: SATSFont.Weight = .default) -> Text {
         font(.satsFont(style, weight: weight))
+/// Internal implementation of a scaled system font
+private struct FontContainerModifier: ViewModifier {
+    let style: SATSFont.TextStyle
+    let weight: SATSFont.Weight
+    let design: Font.Design
+    @ScaledMetric var fontSize: CGFloat
+
+    init(style: SATSFont.TextStyle, weight: SATSFont.Weight, design: Font.Design) {
+        self.style = style
+        self.weight = weight
+        self.design = design
+        self._fontSize = ScaledMetric(wrappedValue: style.size, relativeTo: .from(style.nativeStyle))
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .font(.satsFont(style, scaledSize: fontSize, weight: weight, design: design))
     }
 }
 

--- a/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
@@ -19,7 +19,7 @@ public extension Font {
     }
 }
 
-extension Font.TextStyle {
+public extension Font.TextStyle {
     /// Convert an UIKit text style into a SwiftUI one
     static func from(_ uiFontStyle: UIFont.TextStyle) -> Self {
         switch uiFontStyle {
@@ -31,6 +31,19 @@ extension Font.TextStyle {
         case .subheadline: return .subheadline
         default:
             return .body
+        }
+    }
+}
+
+public extension Font.Weight {
+    static func from(_ weight: SATSFont.Weight) -> Self {
+        switch weight {
+        case .medium:
+            return .medium
+        case .emphasis:
+            return .semibold
+        default:
+            return .regular
         }
     }
 }

--- a/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
@@ -13,9 +13,37 @@ public extension Text {
     }
 }
 
+// MARK: - Font extension
+
 public extension Font {
-    static func satsFont(_ style: SATSFont.TextStyle, weight: SATSFont.Weight = .default) -> Font {
-        Font.custom(weight.font.name, size: style.size, relativeTo: .from(style.nativeStyle))
+    /// This method uses `UIFontMetrics` to calculate the scaled size
+    /// of the font with dyamic type.
+    /// It's recommended to use `satsFont(_:scaledSize:weight:design)` instead
+    static func satsFont(
+        _ style: SATSFont.TextStyle,
+        weight: SATSFont.Weight = .default,
+        design: Font.Design = .default
+    ) -> Font {
+        let scaledFont = UIFontMetrics(forTextStyle: style.nativeStyle).scaledValue(for: style.size)
+        return satsFont(style, scaledSize: scaledFont, weight: weight, design: design)
+    }
+
+    /// Determines the SATS font with the right size to use
+    /// in case we use `.satsFeeling` as the `weight` value, we use a custom font
+    /// otherwise the default `SF Font` will be used.
+    ///
+    /// the `design` parameter is only to be inteded to be used for weights that are not `.satsFeeling`
+    static func satsFont(
+        _ style: SATSFont.TextStyle,
+        scaledSize: CGFloat,
+        weight: SATSFont.Weight = .default,
+        design: Font.Design = .default
+    ) -> Font {
+        if weight == .satsFeeling {
+            return .custom(weight.font.name, size: style.size, relativeTo: .from(style.nativeStyle))
+        } else {
+            return .system(size: scaledSize, weight: .from(weight), design: design)
+        }
     }
 }
 

--- a/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
@@ -11,9 +11,6 @@ public extension View {
     }
 }
 
-public extension Text {
-    func satsFont(_ style: SATSFont.TextStyle, weight: SATSFont.Weight = .default) -> Text {
-        font(.satsFont(style, weight: weight))
 /// Internal implementation of a scaled system font
 private struct FontContainerModifier: ViewModifier {
     let style: SATSFont.TextStyle

--- a/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-SwiftUI.swift
@@ -57,10 +57,10 @@ public extension Font {
         weight: SATSFont.Weight = .default,
         design: Font.Design = .default
     ) -> Font {
-        if weight == .satsFeeling {
-            return .custom(weight.font.name, size: style.size, relativeTo: .from(style.nativeStyle))
-        } else {
+        if weight.prefersSystemFont {
             return .system(size: scaledSize, weight: .from(weight), design: design)
+        } else {
+            return .custom(weight.font.name, size: style.size, relativeTo: .from(style.nativeStyle))
         }
     }
 }

--- a/Sources/SATSCore/DNA/Font/SATSFont-Weight.swift
+++ b/Sources/SATSCore/DNA/Font/SATSFont-Weight.swift
@@ -2,9 +2,10 @@ import SATSType
 public extension SATSFont {
     /// Style variations for a font regarding its weight
     struct Weight: Equatable, Hashable {
-        public init(name: String, font: FontName) {
+        public init(name: String, font: FontName, prefersSystemFont: Bool) {
             self.name = name
             self.font = font
+            self.prefersSystemFont = prefersSystemFont
         }
 
         public static func == (lhs: SATSFont.Weight, rhs: SATSFont.Weight) -> Bool {
@@ -18,12 +19,16 @@ public extension SATSFont {
 
         public let name: String
         public let font: FontName
+        /// use the system font instead of the custom one
+        public let prefersSystemFont: Bool
     }
 }
 
 public extension SATSFont.Weight {
-    static let `default` = SATSFont.Weight(name: "Default", font: InterFont.regular)
-    static let medium = SATSFont.Weight(name: "Medium", font: InterFont.medium)
-    static let emphasis = SATSFont.Weight(name: "Emphasis", font: InterFont.semiBold)
-    static let satsFeeling = SATSFont.Weight(name: "SATS feeling", font: SatsHeadlineFont.boldItalic)
+    static let `default` = SATSFont.Weight(name: "Default", font: InterFont.regular, prefersSystemFont: true)
+    static let medium = SATSFont.Weight(name: "Medium", font: InterFont.medium, prefersSystemFont: true)
+    static let emphasis = SATSFont.Weight(name: "Emphasis", font: InterFont.semiBold, prefersSystemFont: true)
+    static let satsFeeling = SATSFont.Weight(
+        name: "SATS feeling", font: SatsHeadlineFont.boldItalic, prefersSystemFont: false
+    )
 }


### PR DESCRIPTION
# Why?

We should test to use the system font instead of a custom one for most text.
(except headers for now)

⚠️ this PR is not meant to be merged for now, but it's mostly an experiment on what it would take to migrate to the system font.

# What?

- `Font.satsFont` now takes additional `scaledSize` and `design` parameters
- `Text.satsFont() -> Text` is removed
- `View.satsFont() -> some View` will accept the `design` parameter and use the right font depending on the case

# Version Change

breaking change, since now `Text.satsFont()` will return `some View` instead of `Text`