### PR TITLE
Improvement: Control the spacing between text and button in `BannerNotice`

### DIFF
--- a/Sources/SATSCore/Components/BannerNotice/BannerNotice.swift
+++ b/Sources/SATSCore/Components/BannerNotice/BannerNotice.swift
@@ -32,13 +32,12 @@ public struct BannerNotice: View {
     }
 
     public var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: .spacingXS) {
             Text(viewData.message)
                 .satsFont(.basic)
                 .foregroundColor(.onPrimary)
                 .multilineTextAlignment(.leading)
-
-            Spacer()
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             button
         }


### PR DESCRIPTION
# Why?

Today we use a spacer() in an HStack to push the button to the trailing end. Then we do not have control over the layout in terms of spacing between the text and button. 

# What?

Adds a modifier .frame(maxWidth: infinity, aligment: .leading) to the text content

# Version Change

Patch

# UI Changes

| Before | After |
| --- | --- |
|![Skjermbilde 2023-09-04 kl  12 09 46](https://github.com/sats-group/SATSCore-iOS/assets/9019310/017a2972-62fa-4e0d-8f15-a694dea0c094)|![Skjermbilde 2023-09-04 kl  12 08 42](https://github.com/sats-group/SATSCore-iOS/assets/9019310/2f9d3123-3086-47ae-8a36-0d400f97696b)|