### PR TITLE
Feature: watchOS support for SATSCore

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		9BD54AD82ADE947400DC63D9 /* set_version.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = set_version.sh; sourceTree = "<group>"; };
 		9BD54AD92ADE947400DC63D9 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
 		9BD54ADC2ADE94C900DC63D9 /* DemoApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = DemoApp.xctestplan; sourceTree = "<group>"; };
+		9BD54ADD2ADEACF900DC63D9 /* SATSCoreOnWatchOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SATSCoreOnWatchOS.xctestplan; sourceTree = "<group>"; };
 		9BF417172681D25B00E708FD /* ScrollReaderDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollReaderDemoView.swift; sourceTree = "<group>"; };
 		9BF8D1F82679E4A000D4430B /* SATSButtonSwiftUIDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SATSButtonSwiftUIDemoView.swift; sourceTree = "<group>"; };
 		9BFEDCC825CC1F780010A3F6 /* SATSButtonDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SATSButtonDemoView.swift; sourceTree = "<group>"; };
@@ -373,6 +374,7 @@
 			isa = PBXGroup;
 			children = (
 				9BD54ADC2ADE94C900DC63D9 /* DemoApp.xctestplan */,
+				9BD54ADD2ADEACF900DC63D9 /* SATSCoreOnWatchOS.xctestplan */,
 			);
 			path = TestPlans;
 			sourceTree = "<group>";

--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -362,10 +362,10 @@
 		9BD54AD52ADE947400DC63D9 /* ci_scripts */ = {
 			isa = PBXGroup;
 			children = (
-				9BD54AD62ADE947400DC63D9 /* set_changelog.sh */,
-				9BD54AD72ADE947400DC63D9 /* ci_pre_xcodebuild.sh */,
-				9BD54AD82ADE947400DC63D9 /* set_version.sh */,
 				9BD54AD92ADE947400DC63D9 /* ci_post_clone.sh */,
+				9BD54AD72ADE947400DC63D9 /* ci_pre_xcodebuild.sh */,
+				9BD54AD62ADE947400DC63D9 /* set_changelog.sh */,
+				9BD54AD82ADE947400DC63D9 /* set_version.sh */,
 			);
 			path = ci_scripts;
 			sourceTree = SOURCE_ROOT;

--- a/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -32,6 +32,9 @@
             reference = "container:TestPlans/DemoApp.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/SATSCoreOnWatchOS.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/DemoApp/TestPlans/SATSCoreOnWatchOS.xctestplan
+++ b/DemoApp/TestPlans/SATSCoreOnWatchOS.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "7890582D-E979-4B5B-A1F1-F36F121FDC92",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:..",
+        "identifier" : "SATSCoreTests",
+        "name" : "SATSCoreTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "SATSCore",
-    platforms: [.iOS(.v15), .tvOS(.v15)],
+    platforms: [.iOS(.v15), .watchOS(.v9), .tvOS(.v15)],
     products: [
         .library(
             name: "SATSCore",

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Size.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+#if os(iOS)
 public extension SATSButton {
     /// Specifies a resizing behaviour of the button
     struct Size: Equatable {
@@ -60,3 +61,4 @@ public extension SATSButton.Size {
         contentHuggingPriority: .defaultHigh
     )
 }
+#endif

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Style.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-Style.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+#if os(iOS)
 public extension SATSButton {
     /// Specifies a visual theme of the button
     struct Style: Equatable {
@@ -107,3 +108,4 @@ public extension SATSButton.Style {
         backgroundColorDisabled: .ctaDisabled
     )
 }
+#endif

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton-SwiftUI.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if os(iOS)
 public extension View {
     /// Convenience to apply SATSButton styles to SwiftUI buttons
     ///
@@ -94,3 +95,4 @@ private struct SATSButtonSwiftUIStyle: ButtonStyle {
         }
     }
 }
+#endif

--- a/Sources/SATSCore/BasicComponents/SATSButton/SATSButton.swift
+++ b/Sources/SATSCore/BasicComponents/SATSButton/SATSButton.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+#if os(iOS)
 public class SATSButton: UIButton {
     // MARK: Initializers
 
@@ -114,3 +115,4 @@ public class SATSButton: UIButton {
         imageView?.alpha = 1
     }
 }
+#endif

--- a/Sources/SATSCore/BasicComponents/SATSLabel/SATSLabel.swift
+++ b/Sources/SATSCore/BasicComponents/SATSLabel/SATSLabel.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+#if os(iOS)
 public class SATSLabel: UILabel {
     let style: SATSFont.TextStyle
     let weight: SATSFont.Weight
@@ -25,3 +26,4 @@ public class SATSLabel: UILabel {
         fatalError("init(coder:) has not been implemented")
     }
 }
+#endif

--- a/Sources/SATSCore/Components/BannerNotice/BannerNotice.swift
+++ b/Sources/SATSCore/Components/BannerNotice/BannerNotice.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if os(iOS)
 public struct BannerNoticeViewData {
     let message: String
     let action: Action?
@@ -64,3 +65,4 @@ public struct BannerNotice: View {
         }
     }
 }
+#endif

--- a/Sources/SATSCore/Components/ErrorView/ErrorView.swift
+++ b/Sources/SATSCore/Components/ErrorView/ErrorView.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+#if os(iOS)
 private extension SATSButton.Style {
     static let error = SATSButton.Style(
         name: "Error",
@@ -10,6 +11,7 @@ private extension SATSButton.Style {
         backgroundColorDisabled: .primaryDisabled
     )
 }
+#endif
 
 public struct ErrorViewData {
     public let title: String?
@@ -39,6 +41,7 @@ extension ErrorViewData {
     }
 }
 
+#if os(iOS)
 /// A view which displays a title, message and retry button
 public class ErrorView: UIView {
     // MARK: Public properties
@@ -123,3 +126,4 @@ public class ErrorView: UIView {
         onRetry()
     }
 }
+#endif

--- a/Sources/SATSCore/Components/LoadingView/LoadingView.swift
+++ b/Sources/SATSCore/Components/LoadingView/LoadingView.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+#if os(iOS)
 /// Small view that adds a background and center an activity indicator
 ///
 /// It's quite common we use a "full screen" view to show the loading state
@@ -46,3 +47,4 @@ public class LoadingView: UIView {
         startAnimating()
     }
 }
+#endif

--- a/Sources/SATSCore/Components/ModernErrorView/ModernErrorView.swift
+++ b/Sources/SATSCore/Components/ModernErrorView/ModernErrorView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if os(iOS)
 public struct ModernErrorView: View {
     let viewData: ErrorViewData
     var onRetry: (() async -> Void)?
@@ -92,3 +93,4 @@ struct ModernErrorView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if os(iOS)
 /// Notice is a generic way to configure the `NoticeView` component
 /// This struct is available on its own to define custom styles if needed.
 /// Normally using `Notice.error`, `Notice.warning` or `Notice.success`
@@ -169,3 +170,4 @@ public extension Notice {
         public var id: String { rawValue }
     }
 }
+#endif

--- a/Sources/SATSCore/Components/NoticeView/NoticeModifier.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeModifier.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if os(iOS)
 /// Internal modifier, it should only be used via the `View.inlineNotice` method
 struct NoticeModifier: ViewModifier {
     @Binding var notice: Notice?
@@ -86,3 +87,4 @@ public extension View {
         modifier(NoticeModifier(notice: notice, edge: edge))
     }
 }
+#endif

--- a/Sources/SATSCore/Components/NoticeView/NoticeView.swift
+++ b/Sources/SATSCore/Components/NoticeView/NoticeView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if os(iOS)
 public struct NoticeView: View {
     let notice: Notice
     let onTap: (() -> Void)?
@@ -66,3 +67,4 @@ public struct NoticeView: View {
         .foregroundColor(.onSurfaceSecondary)
     }
 }
+#endif

--- a/Sources/SATSCore/Components/RoundLoadingView/RoundLoadingView.swift
+++ b/Sources/SATSCore/Components/RoundLoadingView/RoundLoadingView.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+#if os(iOS)
 public class RoundLoadingView: UIView {
     // MARK: Private properties
 
@@ -102,3 +103,4 @@ public class RoundLoadingView: UIView {
         trackColor = color.withAlphaComponent(0.1)
     }
 }
+#endif

--- a/Sources/SATSCore/Components/WheelPickerView/WheelPickerView-Config.swift
+++ b/Sources/SATSCore/Components/WheelPickerView/WheelPickerView-Config.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 
+#if os(iOS)
 public extension WheelPickerView {
     struct WheelConfig {
         /// The minimum value the picker will allow
@@ -73,3 +74,4 @@ public extension WheelPickerView.WheelConfig {
         )
     }
 }
+#endif

--- a/Sources/SATSCore/Components/WheelPickerView/WheelPickerView.swift
+++ b/Sources/SATSCore/Components/WheelPickerView/WheelPickerView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if os(iOS)
 public struct WheelPickerView: View {
     @Binding public var value: Int
 
@@ -154,3 +155,4 @@ private extension View {
         shadow(color: .black.opacity(0.12), radius: 12, x: 0, y: 0)
     }
 }
+#endif

--- a/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
+++ b/Sources/SATSCore/DNA/Colors/UIKit-Color.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+#if os(iOS)
 public extension UIColor {
     static var primary: UIColor { color(.primary) }
     static var primaryHighlight: UIColor { color(.primaryHighlight) }
@@ -158,3 +159,4 @@ public extension UIColor {
         return color
     }
 }
+#endif

--- a/Sources/SATSCore/DNA/Icons/UIKit-Icon.swift
+++ b/Sources/SATSCore/DNA/Icons/UIKit-Icon.swift
@@ -7,11 +7,13 @@ extension UIImage {
 
     // MARK: Private
 
+    #if canImport(UIKit)
     private static func icon(_ name: IconName) -> UIImage {
-        guard let icon = UIImage(named: name.rawValue, in: Bundle.module, compatibleWith: nil) else {
+        guard let icon = UIImage(named: name.rawValue, in: Bundle.module, with: nil) else {
             preconditionFailure("❌ \(name.rawValue) icon not found!")
         }
 
         return icon
     }
+    #endif
 }

--- a/Sources/SATSCore/Extensions/SwiftUI/Representable/ShareSheet.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Representable/ShareSheet.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 
+#if os(iOS)
+import UIKit
+
 public struct ShareSheet: UIViewControllerRepresentable {
     public typealias Callback = (
         _ activityType: UIActivity.ActivityType?, _ completed: Bool, _ returnedItems: [Any]?, _ error: Error?
@@ -34,3 +37,4 @@ public struct ShareSheet: UIViewControllerRepresentable {
         self.callback = completion
     }
 }
+#endif

--- a/Sources/SATSCore/Extensions/SwiftUI/Representable/SimpleControllerRepresentable.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Representable/SimpleControllerRepresentable.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if os(iOS)
 /// A way to wrap a UIView controller quickly for swiftUI
 public struct SimpleControllerRepresentable<ViewController: UIViewController>: UIViewControllerRepresentable {
     let factory: () -> ViewController
@@ -25,3 +26,4 @@ public struct SimpleControllerRepresentable<ViewController: UIViewController>: U
 
     public func updateUIViewController(_ uiViewController: ViewController, context: Context) {}
 }
+#endif

--- a/Sources/SATSCore/Extensions/SwiftUI/Representable/SimpleRepresentable.swift
+++ b/Sources/SATSCore/Extensions/SwiftUI/Representable/SimpleRepresentable.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if os(iOS)
 /** A simple wrapper for UIViews for SwiftUI
 
  This simple wrapper allows to use a UIKit view within SwiftUI without having to
@@ -32,3 +33,4 @@ public struct SimpleRepresentable<View: UIView>: UIViewRepresentable {
 
     public func updateUIView(_ uiView: View, context: Context) {}
 }
+#endif

--- a/Sources/SATSCore/Extensions/UIKit/UIView-Layout.swift
+++ b/Sources/SATSCore/Extensions/UIKit/UIView-Layout.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+#if os(iOS)
 public extension UIView {
     /// Convenience initalizer to create views ready to be used with autoLayout
     /// - Parameter withAutoLayout
@@ -101,3 +102,4 @@ public protocol Anchorable {
 
 extension UIView: Anchorable {}
 extension UILayoutGuide: Anchorable {}
+#endif

--- a/Tests/SATSCoreTests/ColorsTests.swift
+++ b/Tests/SATSCoreTests/ColorsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftUI
 @testable import SATSCore
 
 class ColorsTests: XCTestCase {
@@ -9,16 +10,16 @@ class ColorsTests: XCTestCase {
     }
 
     // swiftlint:disable:next function_body_length
-    private func colorConstants() -> [UIColor] {
+    private func colorConstants() -> [Color] {
         [
             .backgroundPrimary,
             .backgroundSecondary,
             .backgroundSurfacePrimary,
             .backgroundSurfaceSecondary,
 
-            .secondary,
-            .secondaryHighlight,
-            .secondaryDisabled,
+            .satsSecondary,
+            .satsSecondaryHighlight,
+            .satsSecondaryDisabled,
 
             .clean,
             .cleanHighlight,
@@ -101,9 +102,9 @@ class ColorsTests: XCTestCase {
             .onSurfaceSecondary,
             .onSurfaceDisabled,
 
-            .primary,
-            .primaryHighlight,
-            .primaryDisabled,
+            .satsPrimary,
+            .satsPrimaryHighlight,
+            .satsPrimaryDisabled,
 
             .navigation,
 


### PR DESCRIPTION
# Why?

To revamp the watchOS app we also want to use the design system, mainly colors and so on for watchOS

# What?

- Add support for watchOS for SATSCore
- Add conditional compilation for UIKit components
- Update SATSType from 0.0.3 to 0.0.4
- Test SwiftUI colors instead of UIColor, so It can run for iOS and watchOS targets
- Add a TestPlan to run test on watchOS

# Version Change

Minor