### PR TITLE
Improvement: Adds `actionTitle` and `action` to Notice.warning

### DIFF
--- a/Sources/SATSCore/Components/NoticeView/Notice.swift
+++ b/Sources/SATSCore/Components/NoticeView/Notice.swift
@@ -102,7 +102,9 @@ public struct Notice {
         title: String? = nil,
         message: String,
         autoDismiss: Bool = true,
-        includeHaptic: Bool = true
+        includeHaptic: Bool = true,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
     ) -> Notice {
         Notice(
             icon: Image(systemName: "exclamationmark.triangle"),
@@ -110,7 +112,9 @@ public struct Notice {
             message: message,
             autoDismiss: autoDismiss,
             tintColor: .signalWarning,
-            hapticType: includeHaptic ? .warning : nil
+            hapticType: includeHaptic ? .warning : nil,
+            actionTitle: actionTitle,
+            action: action
         )
     }
 


### PR DESCRIPTION
# Why?

There is a need to add an action to a warning notice in the member app. 

# What?

- Adds new arguments to Notice.warning() initializer. 

# Version Change

Minor